### PR TITLE
Convert to C89 (ANSI C)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FLAGS = -std=c99 -g -O0
+FLAGS = -std=c89 -g -O0
 GTK2_INC = `pkg-config --cflags gtk+-2.0 glib-2.0` 
 GTK2_LIB = `pkg-config --libs gtk+-2.0 glib-2.0` -lm
 #GTK2_LIB = `pkg-config --libs gtk+-2.0` -lm

--- a/include/field_snapshot.h
+++ b/include/field_snapshot.h
@@ -29,11 +29,11 @@
 typedef struct
 {
     MinesField field;
-    gint index; // snapshot index
+    gint index; /* snapshot index */
     GTimeVal time;
     gint pointer_x;
     gint pointer_y;
-    gint pointer_mask;//GdkModifierType 
+    gint pointer_mask; /* GdkModifierType */
 } FieldSnapshot;
 
 gboolean video_recorder_function(gpointer *data);

--- a/include/mines_field.h
+++ b/include/mines_field.h
@@ -42,7 +42,7 @@ typedef struct
     gint opened_count;
     gboolean fully_opened;
     gint marked_count;
-    int **cell; // matrix
+    int **cell; /* matrix */
 } MinesField;
 
 #define max(x, y) ( (x) > (y) ? (x) : (y) )


### PR DESCRIPTION
Since no C99 specific features are used (other than a few C++-style comments), we can build with C89 instead.

If any C99 features need to be used in the future, it can be switched back.