### PR TITLE
Reformat code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,30 +21,34 @@
 # SOFTWARE.
 
 FLAGS = -std=c99 -g -O0
-GTK2_INC = `pkg-config --cflags gtk+-2.0 glib-2.0` 
+GTK2_INC = `pkg-config --cflags gtk+-2.0 glib-2.0`
 GTK2_LIB = `pkg-config --libs gtk+-2.0 glib-2.0` -lm
 #GTK2_LIB = `pkg-config --libs gtk+-2.0` -lm
 
 miner : field_snapshot.o display_field.o mines_field.o main.o scores_callbacks.o scores_interface.o scores_support.o
 	gcc $(FLAGS) -o miner field_snapshot.o scores_callbacks.o scores_interface.o scores_support.o main.o display_field.o mines_field.o $(GTK2_LIB)
+
 main.o : main.c
 	gcc $(FLAGS) -c main.c -o main.o $(GTK2_INC)
+
 display_field.o : display_field.c
 	gcc $(FLAGS) -c display_field.c -o display_field.o $(GTK2_INC)
+
 mines_field.o : mines_field.c 
 	gcc $(FLAGS) -c mines_field.c -o mines_field.o $(GTK2_INC)
+
 field_snapshot.o : field_snapshot.c
 	gcc $(FLAGS) -c field_snapshot.c -o field_snapshot.o $(GTK2_INC)
-#dialog
+
+# dialog
 scores_callbacks.o : dialog/scores/callbacks.c
 	gcc $(FLAGS) $(GTK2_INC) -c dialog/scores/callbacks.c -o scores_callbacks.o
+
 scores_interface.o : dialog/scores/interface.c
 	gcc $(FLAGS) $(GTK2_INC) -c dialog/scores/interface.c -o scores_interface.o
+
 scores_support.o : dialog/scores/support.c
 	gcc $(FLAGS) $(GTK2_INC) -c dialog/scores/support.c -o scores_support.o
+
 clean : 
 	rm -f *.o miner
-
-
-
-

--- a/dialog/scores/callbacks.c
+++ b/dialog/scores/callbacks.c
@@ -34,17 +34,17 @@
 
 
 void
-on_window_score_activate_default       (GtkWindow       *window,
-                                        gpointer         user_data)
+on_window_score_activate_default(GtkWindow       *window,
+                                 gpointer         user_data)
 {
 
 }
 
-gboolean 
-on_button_ok_clicked	(GtkWidget 	*widget, 
-			gpointer 	data)
+gboolean
+on_button_ok_clicked(GtkWidget 	*widget,
+                     gpointer 	data)
 {
-   gtk_widget_destroy(GTK_WIDGET(data));   
+	gtk_widget_destroy(GTK_WIDGET(data));
 }
 
 

--- a/dialog/scores/callbacks.h
+++ b/dialog/scores/callbacks.h
@@ -26,8 +26,8 @@
 
 
 void
-on_window_score_activate_default       (GtkWindow       *window,
-                                        gpointer         user_data);
+on_window_score_activate_default(GtkWindow       *window,
+                                 gpointer         user_data);
 gboolean
-on_button_ok_clicked       (GtkWidget       *widget,
-                                        gpointer         user_data);
+on_button_ok_clicked(GtkWidget       *widget,
+                     gpointer         user_data);

--- a/dialog/scores/interface.c
+++ b/dialog/scores/interface.c
@@ -53,147 +53,147 @@
   g_object_set_data (G_OBJECT (component), name, widget)
 
 GtkWidget*
-create_window_score (MinerConfig *config)
+create_window_score(MinerConfig *config)
 {
-    GtkWidget *window_score;
-    GtkWidget *vbox_score;
-    GtkWidget *score_label;
-    GtkWidget *hbox_small;
-    GtkWidget *label_small;
-    GtkWidget *label_small_time;
-    GtkWidget *hbox_medium;
-    GtkWidget *label_medium;
-    GtkWidget *label_medium_time;
-    GtkWidget *hbox_large;
-    GtkWidget *label_large;
-    GtkWidget *label_large_time;
-    GtkWidget *button_ok;
-    GtkWidget *alignment1;
-    GtkWidget *hbox5;
-    GtkWidget *image1;
-    GtkWidget *label11;
+	GtkWidget *window_score;
+	GtkWidget *vbox_score;
+	GtkWidget *score_label;
+	GtkWidget *hbox_small;
+	GtkWidget *label_small;
+	GtkWidget *label_small_time;
+	GtkWidget *hbox_medium;
+	GtkWidget *label_medium;
+	GtkWidget *label_medium_time;
+	GtkWidget *hbox_large;
+	GtkWidget *label_large;
+	GtkWidget *label_large_time;
+	GtkWidget *button_ok;
+	GtkWidget *alignment1;
+	GtkWidget *hbox5;
+	GtkWidget *image1;
+	GtkWidget *label11;
 
-    gchar str_time[0x10];
-    gint second;
-    gint dec_second;
+	gchar str_time[0x10];
+	gint second;
+	gint dec_second;
 
-    window_score = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-    gtk_container_set_border_width (GTK_CONTAINER (window_score), 2);
-    gtk_window_set_title (GTK_WINDOW (window_score), "score");
-    gtk_window_set_position (GTK_WINDOW (window_score), GTK_WIN_POS_CENTER_ON_PARENT);
-    gtk_window_set_modal (GTK_WINDOW (window_score), TRUE);
-    gtk_window_set_resizable (GTK_WINDOW (window_score), FALSE);
-    gtk_window_set_destroy_with_parent (GTK_WINDOW (window_score), TRUE);
-    gtk_window_set_type_hint (GTK_WINDOW (window_score), GDK_WINDOW_TYPE_HINT_DIALOG);
+	window_score = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+	gtk_container_set_border_width(GTK_CONTAINER(window_score), 2);
+	gtk_window_set_title(GTK_WINDOW(window_score), "score");
+	gtk_window_set_position(GTK_WINDOW(window_score), GTK_WIN_POS_CENTER_ON_PARENT);
+	gtk_window_set_modal(GTK_WINDOW(window_score), TRUE);
+	gtk_window_set_resizable(GTK_WINDOW(window_score), FALSE);
+	gtk_window_set_destroy_with_parent(GTK_WINDOW(window_score), TRUE);
+	gtk_window_set_type_hint(GTK_WINDOW(window_score), GDK_WINDOW_TYPE_HINT_DIALOG);
 
-    vbox_score = gtk_vbox_new (TRUE, 2);
-    gtk_widget_show (vbox_score);
-    gtk_container_add (GTK_CONTAINER (window_score), vbox_score);
-    gtk_widget_set_size_request (vbox_score, 175, 233);
-    gtk_container_set_border_width (GTK_CONTAINER (vbox_score), 20);
+	vbox_score = gtk_vbox_new(TRUE, 2);
+	gtk_widget_show(vbox_score);
+	gtk_container_add(GTK_CONTAINER(window_score), vbox_score);
+	gtk_widget_set_size_request(vbox_score, 175, 233);
+	gtk_container_set_border_width(GTK_CONTAINER(vbox_score), 20);
 
-    score_label = gtk_label_new ("Score");
-    gtk_widget_show (score_label);
-    gtk_box_pack_start (GTK_BOX (vbox_score), score_label, FALSE, FALSE, 0);
-    gtk_label_set_justify (GTK_LABEL (score_label), GTK_JUSTIFY_CENTER);
-    gtk_label_set_ellipsize (GTK_LABEL (score_label), PANGO_ELLIPSIZE_MIDDLE);
-    gtk_label_set_single_line_mode (GTK_LABEL (score_label), TRUE);
+	score_label = gtk_label_new("Score");
+	gtk_widget_show(score_label);
+	gtk_box_pack_start(GTK_BOX(vbox_score), score_label, FALSE, FALSE, 0);
+	gtk_label_set_justify(GTK_LABEL(score_label), GTK_JUSTIFY_CENTER);
+	gtk_label_set_ellipsize(GTK_LABEL(score_label), PANGO_ELLIPSIZE_MIDDLE);
+	gtk_label_set_single_line_mode(GTK_LABEL(score_label), TRUE);
 
-    hbox_small = gtk_hbox_new (FALSE, 5);
-    gtk_widget_show (hbox_small);
-    gtk_box_pack_start (GTK_BOX (vbox_score), hbox_small, FALSE, FALSE, 10);
+	hbox_small = gtk_hbox_new(FALSE, 5);
+	gtk_widget_show(hbox_small);
+	gtk_box_pack_start(GTK_BOX(vbox_score), hbox_small, FALSE, FALSE, 10);
 
-    label_small = gtk_label_new ("Small time:");
-    gtk_widget_show (label_small);
-    gtk_box_pack_start (GTK_BOX (hbox_small), label_small, FALSE, FALSE, 0);
+	label_small = gtk_label_new("Small time:");
+	gtk_widget_show(label_small);
+	gtk_box_pack_start(GTK_BOX(hbox_small), label_small, FALSE, FALSE, 0);
 
-    second = config->small_time.tv_sec;
-    dec_second = config->small_time.tv_usec/10000;
-    g_sprintf(str_time, "%3.3d:%2.2d", second, dec_second);
-    label_small_time = gtk_label_new (str_time);
-    gtk_widget_show (label_small_time);
-    gtk_box_pack_start (GTK_BOX (hbox_small), label_small_time, FALSE, FALSE, 0);
+	second = config->small_time.tv_sec;
+	dec_second = config->small_time.tv_usec / 10000;
+	g_sprintf(str_time, "%3.3d:%2.2d", second, dec_second);
+	label_small_time = gtk_label_new(str_time);
+	gtk_widget_show(label_small_time);
+	gtk_box_pack_start(GTK_BOX(hbox_small), label_small_time, FALSE, FALSE, 0);
 
-    hbox_medium = gtk_hbox_new (FALSE, 0);
-    gtk_widget_show (hbox_medium);
-    gtk_box_pack_start (GTK_BOX (vbox_score), hbox_medium, FALSE, TRUE, 10);
+	hbox_medium = gtk_hbox_new(FALSE, 0);
+	gtk_widget_show(hbox_medium);
+	gtk_box_pack_start(GTK_BOX(vbox_score), hbox_medium, FALSE, TRUE, 10);
 
-    label_medium = gtk_label_new ("Medium time: ");
-    gtk_widget_show (label_medium);
-    gtk_box_pack_start (GTK_BOX (hbox_medium), label_medium, FALSE, FALSE, 0);
+	label_medium = gtk_label_new("Medium time: ");
+	gtk_widget_show(label_medium);
+	gtk_box_pack_start(GTK_BOX(hbox_medium), label_medium, FALSE, FALSE, 0);
 
-    second = config->medium_time.tv_sec;
-    dec_second = config->medium_time.tv_usec/10000;
-    g_sprintf(str_time, "%3.3d:%2.2d", second, dec_second);
-    label_medium_time = gtk_label_new (str_time);
-    gtk_widget_show (label_medium_time);
-    gtk_box_pack_start (GTK_BOX (hbox_medium), label_medium_time, FALSE, FALSE, 0);
+	second = config->medium_time.tv_sec;
+	dec_second = config->medium_time.tv_usec / 10000;
+	g_sprintf(str_time, "%3.3d:%2.2d", second, dec_second);
+	label_medium_time = gtk_label_new(str_time);
+	gtk_widget_show(label_medium_time);
+	gtk_box_pack_start(GTK_BOX(hbox_medium), label_medium_time, FALSE, FALSE, 0);
 
-    hbox_large = gtk_hbox_new (FALSE, 0);
-    gtk_widget_show (hbox_large);
-    gtk_box_pack_start (GTK_BOX (vbox_score), hbox_large, FALSE, TRUE, 10);
+	hbox_large = gtk_hbox_new(FALSE, 0);
+	gtk_widget_show(hbox_large);
+	gtk_box_pack_start(GTK_BOX(vbox_score), hbox_large, FALSE, TRUE, 10);
 
-    label_large = gtk_label_new ("Large time: ");
-    gtk_widget_show (label_large);
-    gtk_box_pack_start (GTK_BOX (hbox_large), label_large, FALSE, FALSE, 0);
+	label_large = gtk_label_new("Large time: ");
+	gtk_widget_show(label_large);
+	gtk_box_pack_start(GTK_BOX(hbox_large), label_large, FALSE, FALSE, 0);
 
-    second = config->large_time.tv_sec;
-    dec_second = config->large_time.tv_usec/10000;
-    g_sprintf(str_time, "%3.3d:%2.2d", second, dec_second);
-    label_large_time = gtk_label_new (str_time);
-    gtk_widget_show (label_large_time);
-    gtk_box_pack_start (GTK_BOX (hbox_large), label_large_time, FALSE, FALSE, 0);
+	second = config->large_time.tv_sec;
+	dec_second = config->large_time.tv_usec / 10000;
+	g_sprintf(str_time, "%3.3d:%2.2d", second, dec_second);
+	label_large_time = gtk_label_new(str_time);
+	gtk_widget_show(label_large_time);
+	gtk_box_pack_start(GTK_BOX(hbox_large), label_large_time, FALSE, FALSE, 0);
 
-    button_ok = gtk_button_new ();
-    gtk_widget_show (button_ok);
-    gtk_box_pack_end (GTK_BOX (vbox_score), button_ok, FALSE, FALSE, 0);
-    gtk_widget_set_size_request (button_ok, 48, 32);
-    GTK_WIDGET_UNSET_FLAGS (button_ok, GTK_CAN_FOCUS);
-    gtk_button_set_relief (GTK_BUTTON (button_ok), GTK_RELIEF_HALF);
+	button_ok = gtk_button_new();
+	gtk_widget_show(button_ok);
+	gtk_box_pack_end(GTK_BOX(vbox_score), button_ok, FALSE, FALSE, 0);
+	gtk_widget_set_size_request(button_ok, 48, 32);
+	GTK_WIDGET_UNSET_FLAGS(button_ok, GTK_CAN_FOCUS);
+	gtk_button_set_relief(GTK_BUTTON(button_ok), GTK_RELIEF_HALF);
 
-    alignment1 = gtk_alignment_new (0.5, 0.5, 0, 0);
-    gtk_widget_show (alignment1);
-    gtk_container_add (GTK_CONTAINER (button_ok), alignment1);
+	alignment1 = gtk_alignment_new(0.5, 0.5, 0, 0);
+	gtk_widget_show(alignment1);
+	gtk_container_add(GTK_CONTAINER(button_ok), alignment1);
 
-    hbox5 = gtk_hbox_new (FALSE, 2);
-    gtk_widget_show (hbox5);
-    gtk_container_add (GTK_CONTAINER (alignment1), hbox5);
+	hbox5 = gtk_hbox_new(FALSE, 2);
+	gtk_widget_show(hbox5);
+	gtk_container_add(GTK_CONTAINER(alignment1), hbox5);
 
-    image1 = gtk_image_new_from_stock ("gtk-ok", GTK_ICON_SIZE_BUTTON);
-    gtk_widget_show (image1);
-    gtk_box_pack_start (GTK_BOX (hbox5), image1, FALSE, FALSE, 0);
+	image1 = gtk_image_new_from_stock("gtk-ok", GTK_ICON_SIZE_BUTTON);
+	gtk_widget_show(image1);
+	gtk_box_pack_start(GTK_BOX(hbox5), image1, FALSE, FALSE, 0);
 
-    label11 = gtk_label_new_with_mnemonic ("ok");
-    gtk_widget_show (label11);
-    gtk_box_pack_start (GTK_BOX (hbox5), label11, FALSE, FALSE, 0);
+	label11 = gtk_label_new_with_mnemonic("ok");
+	gtk_widget_show(label11);
+	gtk_box_pack_start(GTK_BOX(hbox5), label11, FALSE, FALSE, 0);
 
-    g_signal_connect ((gpointer) window_score, "activate_default",
-		    G_CALLBACK (on_window_score_activate_default),
-		    NULL);
+	g_signal_connect((gpointer) window_score, "activate_default",
+	                 G_CALLBACK(on_window_score_activate_default),
+	                 NULL);
 
-    g_signal_connect ((gpointer) button_ok, "clicked",
-		    G_CALLBACK (on_button_ok_clicked),
-		    window_score);
+	g_signal_connect((gpointer) button_ok, "clicked",
+	                 G_CALLBACK(on_button_ok_clicked),
+	                 window_score);
 
-    /* Store pointers to all widgets, for use by lookup_widget(). */
-    GLADE_HOOKUP_OBJECT_NO_REF (window_score, window_score, "window_score");
-    GLADE_HOOKUP_OBJECT (window_score, vbox_score, "vbox_score");
-    GLADE_HOOKUP_OBJECT (window_score, score_label, "score_label");
-    GLADE_HOOKUP_OBJECT (window_score, hbox_small, "hbox_small");
-    GLADE_HOOKUP_OBJECT (window_score, label_small, "label_small");
-    GLADE_HOOKUP_OBJECT (window_score, label_small_time, "label_small_time");
-    GLADE_HOOKUP_OBJECT (window_score, hbox_medium, "hbox_medium");
-    GLADE_HOOKUP_OBJECT (window_score, label_medium, "label_medium");
-    GLADE_HOOKUP_OBJECT (window_score, label_medium_time, "label_medium_time");
-    GLADE_HOOKUP_OBJECT (window_score, hbox_large, "hbox_large");
-    GLADE_HOOKUP_OBJECT (window_score, label_large, "label_large");
-    GLADE_HOOKUP_OBJECT (window_score, label_large_time, "label_large_time");
-    GLADE_HOOKUP_OBJECT (window_score, button_ok, "button_ok");
-    GLADE_HOOKUP_OBJECT (window_score, alignment1, "alignment1");
-    GLADE_HOOKUP_OBJECT (window_score, hbox5, "hbox5");
-    GLADE_HOOKUP_OBJECT (window_score, image1, "image1");
-    GLADE_HOOKUP_OBJECT (window_score, label11, "label11");
+	/* Store pointers to all widgets, for use by lookup_widget(). */
+	GLADE_HOOKUP_OBJECT_NO_REF(window_score, window_score, "window_score");
+	GLADE_HOOKUP_OBJECT(window_score, vbox_score, "vbox_score");
+	GLADE_HOOKUP_OBJECT(window_score, score_label, "score_label");
+	GLADE_HOOKUP_OBJECT(window_score, hbox_small, "hbox_small");
+	GLADE_HOOKUP_OBJECT(window_score, label_small, "label_small");
+	GLADE_HOOKUP_OBJECT(window_score, label_small_time, "label_small_time");
+	GLADE_HOOKUP_OBJECT(window_score, hbox_medium, "hbox_medium");
+	GLADE_HOOKUP_OBJECT(window_score, label_medium, "label_medium");
+	GLADE_HOOKUP_OBJECT(window_score, label_medium_time, "label_medium_time");
+	GLADE_HOOKUP_OBJECT(window_score, hbox_large, "hbox_large");
+	GLADE_HOOKUP_OBJECT(window_score, label_large, "label_large");
+	GLADE_HOOKUP_OBJECT(window_score, label_large_time, "label_large_time");
+	GLADE_HOOKUP_OBJECT(window_score, button_ok, "button_ok");
+	GLADE_HOOKUP_OBJECT(window_score, alignment1, "alignment1");
+	GLADE_HOOKUP_OBJECT(window_score, hbox5, "hbox5");
+	GLADE_HOOKUP_OBJECT(window_score, image1, "image1");
+	GLADE_HOOKUP_OBJECT(window_score, label11, "label11");
 
-    return window_score;
+	return window_score;
 }
 

--- a/dialog/scores/interface.h
+++ b/dialog/scores/interface.h
@@ -27,4 +27,4 @@
  */
 
 #include "../../include/main.h"
-GtkWidget* create_window_score (MinerConfig *config);
+GtkWidget* create_window_score(MinerConfig *config);

--- a/dialog/scores/support.c
+++ b/dialog/scores/support.c
@@ -41,128 +41,128 @@
 #include "support.h"
 
 GtkWidget*
-lookup_widget                          (GtkWidget       *widget,
-                                        const gchar     *widget_name)
+lookup_widget(GtkWidget       *widget,
+              const gchar     *widget_name)
 {
-  GtkWidget *parent, *found_widget;
+	GtkWidget *parent, *found_widget;
 
-  for (;;)
-    {
-      if (GTK_IS_MENU (widget))
-        parent = gtk_menu_get_attach_widget (GTK_MENU (widget));
-      else
-        parent = widget->parent;
-      if (!parent)
-        parent = (GtkWidget*) g_object_get_data (G_OBJECT (widget), "GladeParentKey");
-      if (parent == NULL)
-        break;
-      widget = parent;
-    }
+	for (;;)
+	{
+		if (GTK_IS_MENU(widget))
+			parent = gtk_menu_get_attach_widget(GTK_MENU(widget));
+		else
+			parent = widget->parent;
+		if (!parent)
+			parent = (GtkWidget*) g_object_get_data(G_OBJECT(widget), "GladeParentKey");
+		if (parent == NULL)
+			break;
+		widget = parent;
+	}
 
-  found_widget = (GtkWidget*) g_object_get_data (G_OBJECT (widget),
-                                                 widget_name);
-  if (!found_widget)
-    g_warning ("Widget not found: %s", widget_name);
-  return found_widget;
+	found_widget = (GtkWidget*) g_object_get_data(G_OBJECT(widget),
+	               widget_name);
+	if (!found_widget)
+		g_warning("Widget not found: %s", widget_name);
+	return found_widget;
 }
 
 static GList *pixmaps_directories = NULL;
 
 /* Use this function to set the directory containing installed pixmaps. */
 void
-add_pixmap_directory                   (const gchar     *directory)
+add_pixmap_directory(const gchar     *directory)
 {
-  pixmaps_directories = g_list_prepend (pixmaps_directories,
-                                        g_strdup (directory));
+	pixmaps_directories = g_list_prepend(pixmaps_directories,
+	                                     g_strdup(directory));
 }
 
 /* This is an internally used function to find pixmap files. */
 static gchar*
-find_pixmap_file                       (const gchar     *filename)
+find_pixmap_file(const gchar     *filename)
 {
-  GList *elem;
+	GList *elem;
 
-  /* We step through each of the pixmaps directory to find it. */
-  elem = pixmaps_directories;
-  while (elem)
-    {
-      gchar *pathname = g_strdup_printf ("%s%s%s", (gchar*)elem->data,
-                                         G_DIR_SEPARATOR_S, filename);
-      if (g_file_test (pathname, G_FILE_TEST_EXISTS))
-        return pathname;
-      g_free (pathname);
-      elem = elem->next;
-    }
-  return NULL;
+	/* We step through each of the pixmaps directory to find it. */
+	elem = pixmaps_directories;
+	while (elem)
+	{
+		gchar *pathname = g_strdup_printf("%s%s%s", (gchar*)elem->data,
+		                                  G_DIR_SEPARATOR_S, filename);
+		if (g_file_test(pathname, G_FILE_TEST_EXISTS))
+			return pathname;
+		g_free(pathname);
+		elem = elem->next;
+	}
+	return NULL;
 }
 
 /* This is an internally used function to create pixmaps. */
 GtkWidget*
-create_pixmap                          (GtkWidget       *widget,
-                                        const gchar     *filename)
+create_pixmap(GtkWidget       *widget,
+              const gchar     *filename)
 {
-  gchar *pathname = NULL;
-  GtkWidget *pixmap;
+	gchar *pathname = NULL;
+	GtkWidget *pixmap;
 
-  if (!filename || !filename[0])
-      return gtk_image_new ();
+	if (!filename || !filename[0])
+		return gtk_image_new();
 
-  pathname = find_pixmap_file (filename);
+	pathname = find_pixmap_file(filename);
 
-  if (!pathname)
-    {
-      g_warning ("Couldn't find pixmap file: %s", filename);
-      return gtk_image_new ();
-    }
+	if (!pathname)
+	{
+		g_warning("Couldn't find pixmap file: %s", filename);
+		return gtk_image_new();
+	}
 
-  pixmap = gtk_image_new_from_file (pathname);
-  g_free (pathname);
-  return pixmap;
+	pixmap = gtk_image_new_from_file(pathname);
+	g_free(pathname);
+	return pixmap;
 }
 
 /* This is an internally used function to create pixmaps. */
 GdkPixbuf*
-create_pixbuf                          (const gchar     *filename)
+create_pixbuf(const gchar     *filename)
 {
-  gchar *pathname = NULL;
-  GdkPixbuf *pixbuf;
-  GError *error = NULL;
+	gchar *pathname = NULL;
+	GdkPixbuf *pixbuf;
+	GError *error = NULL;
 
-  if (!filename || !filename[0])
-      return NULL;
+	if (!filename || !filename[0])
+		return NULL;
 
-  pathname = find_pixmap_file (filename);
+	pathname = find_pixmap_file(filename);
 
-  if (!pathname)
-    {
-      g_warning ("Couldn't find pixmap file: %s", filename);
-      return NULL;
-    }
+	if (!pathname)
+	{
+		g_warning("Couldn't find pixmap file: %s", filename);
+		return NULL;
+	}
 
-  pixbuf = gdk_pixbuf_new_from_file (pathname, &error);
-  if (!pixbuf)
-    {
-      fprintf (stderr, "Failed to load pixbuf file: %s: %s\n",
-               pathname, error->message);
-      g_error_free (error);
-    }
-  g_free (pathname);
-  return pixbuf;
+	pixbuf = gdk_pixbuf_new_from_file(pathname, &error);
+	if (!pixbuf)
+	{
+		fprintf(stderr, "Failed to load pixbuf file: %s: %s\n",
+		        pathname, error->message);
+		g_error_free(error);
+	}
+	g_free(pathname);
+	return pixbuf;
 }
 
 /* This is used to set ATK action descriptions. */
 void
-glade_set_atk_action_description       (AtkAction       *action,
-                                        const gchar     *action_name,
-                                        const gchar     *description)
+glade_set_atk_action_description(AtkAction       *action,
+                                 const gchar     *action_name,
+                                 const gchar     *description)
 {
-  gint n_actions, i;
+	gint n_actions, i;
 
-  n_actions = atk_action_get_n_actions (action);
-  for (i = 0; i < n_actions; i++)
-    {
-      if (!strcmp (atk_action_get_name (action, i), action_name))
-        atk_action_set_description (action, i, description);
-    }
+	n_actions = atk_action_get_n_actions(action);
+	for (i = 0; i < n_actions; i++)
+	{
+		if (!strcmp(atk_action_get_name(action, i), action_name))
+			atk_action_set_description(action, i, description);
+	}
 }
 

--- a/dialog/scores/support.h
+++ b/dialog/scores/support.h
@@ -42,12 +42,12 @@
  * or alternatively any widget in the component, and the name of the widget
  * you want returned.
  */
-GtkWidget*  lookup_widget              (GtkWidget       *widget,
-                                        const gchar     *widget_name);
+GtkWidget*  lookup_widget(GtkWidget       *widget,
+                          const gchar     *widget_name);
 
 
 /* Use this function to set the directory containing installed pixmaps. */
-void        add_pixmap_directory       (const gchar     *directory);
+void        add_pixmap_directory(const gchar     *directory);
 
 
 /*
@@ -55,14 +55,14 @@ void        add_pixmap_directory       (const gchar     *directory);
  */
 
 /* This is used to create the pixmaps used in the interface. */
-GtkWidget*  create_pixmap              (GtkWidget       *widget,
-                                        const gchar     *filename);
+GtkWidget*  create_pixmap(GtkWidget       *widget,
+                          const gchar     *filename);
 
 /* This is used to create the pixbufs used in the interface. */
-GdkPixbuf*  create_pixbuf              (const gchar     *filename);
+GdkPixbuf*  create_pixbuf(const gchar     *filename);
 
 /* This is used to set ATK action descriptions. */
-void        glade_set_atk_action_description (AtkAction       *action,
-                                              const gchar     *action_name,
-                                              const gchar     *description);
+void        glade_set_atk_action_description(AtkAction       *action,
+        const gchar     *action_name,
+        const gchar     *description);
 

--- a/display_field.c
+++ b/display_field.c
@@ -31,178 +31,178 @@
 
 void display_field_admit_state(DisplayField *df)
 {
-    df->state_handler(df->object, df->field);
+	df->state_handler(df->object, df->field);
 }
 
-DisplayField* display_field_new(MinesField *mf, 
-	GObject *object,
-	StateHandler state_handler,
-       	gint cell_size)
+DisplayField* display_field_new(MinesField *mf,
+                                GObject *object,
+                                StateHandler state_handler,
+                                gint cell_size)
 {
-    DisplayField *display_field;
+	DisplayField *display_field;
 
-    display_field = (DisplayField*)g_malloc(sizeof(DisplayField));
-    display_field->widget = gtk_drawing_area_new();
-    display_field->cell_size = cell_size;
-    display_field->field = mf;
-    display_field->object = G_OBJECT(object);
-    display_field->state_handler = state_handler;
+	display_field = (DisplayField*)g_malloc(sizeof(DisplayField));
+	display_field->widget = gtk_drawing_area_new();
+	display_field->cell_size = cell_size;
+	display_field->field = mf;
+	display_field->object = G_OBJECT(object);
+	display_field->state_handler = state_handler;
 
-    gtk_widget_set_size_request(display_field->widget, 
-	    display_field->cell_size*mf->width,
-	    display_field->cell_size*mf->height); 
+	gtk_widget_set_size_request(display_field->widget,
+	                            display_field->cell_size * mf->width,
+	                            display_field->cell_size * mf->height);
 
-    gtk_widget_add_events(display_field->widget, GDK_BUTTON_PRESS_MASK);
-    gtk_widget_add_events(display_field->widget, GDK_BUTTON_RELEASE_MASK);
-    gtk_widget_add_events(display_field->widget, GDK_BUTTON_MOTION_MASK);
+	gtk_widget_add_events(display_field->widget, GDK_BUTTON_PRESS_MASK);
+	gtk_widget_add_events(display_field->widget, GDK_BUTTON_RELEASE_MASK);
+	gtk_widget_add_events(display_field->widget, GDK_BUTTON_MOTION_MASK);
 
-    g_signal_connect(G_OBJECT(display_field->widget), "expose_event", 
-	    G_CALLBACK(display_field_expose_event), 
-	    (gpointer)display_field);
-    g_signal_connect(G_OBJECT(display_field->widget), "button_press_event", 
-	    G_CALLBACK(display_field_button_event), 
-	    (gpointer)display_field);
-    g_signal_connect(G_OBJECT(display_field->widget), "button_release_event", 
-	    G_CALLBACK(display_field_button_event), 
-	    (gpointer)display_field);
-    
-/*  may be I should use it in future in order to change rendering behavor 
-    g_signal_connect(G_OBJECT(display_field->widget), "motion_notify_event", 
-	    G_CALLBACK(display_field_motion_event), 
-	    (gpointer)display_field); */
+	g_signal_connect(G_OBJECT(display_field->widget), "expose_event",
+	                 G_CALLBACK(display_field_expose_event),
+	                 (gpointer)display_field);
+	g_signal_connect(G_OBJECT(display_field->widget), "button_press_event",
+	                 G_CALLBACK(display_field_button_event),
+	                 (gpointer)display_field);
+	g_signal_connect(G_OBJECT(display_field->widget), "button_release_event",
+	                 G_CALLBACK(display_field_button_event),
+	                 (gpointer)display_field);
 
-    return (display_field);
+	/*  may be I should use it in future in order to change rendering behavor
+	    g_signal_connect(G_OBJECT(display_field->widget), "motion_notify_event",
+		    G_CALLBACK(display_field_motion_event),
+		    (gpointer)display_field); */
+
+	return (display_field);
 }
 
 /* events functions */
 gboolean display_field_expose_event(GtkWidget *widget,
-       	GdkEventExpose *event,
-       	gpointer df)
+                                    GdkEventExpose *event,
+                                    gpointer df)
 {
-    display_field_show(widget->window, df, TRUE);
-    return FALSE;
+	display_field_show(widget->window, df, TRUE);
+	return FALSE;
 }
 
 gboolean display_field_button_event(GtkWidget *widget,
-	GdkEventButton *event,
-       	gpointer data)
+                                    GdkEventButton *event,
+                                    gpointer data)
 {
-    DisplayField *df;
-    MinesField *mf;
-    gint action = -1; 
-    gint pressed_state = PRESSED_NONE;
-    gint x, y;
+	DisplayField *df;
+	MinesField *mf;
+	gint action = -1;
+	gint pressed_state = PRESSED_NONE;
+	gint x, y;
 
-    df = (DisplayField*)data;
-    mf = df->field;
-    x = (gint)event->x/df->cell_size;
-    y = (gint)event->y/df->cell_size;
+	df = (DisplayField*)data;
+	mf = df->field;
+	x = (gint)event->x / df->cell_size;
+	y = (gint)event->y / df->cell_size;
 
-    if (x == mf->width)
-        x -= 1;
+	if (x == mf->width)
+		x -= 1;
 
-    if (y == mf->height)
-        y -= 1;
+	if (y == mf->height)
+		y -= 1;
 
-    if (x > mf->width || y > mf->height) {
-        fprintf(stderr, "cell coordinates are out of the box (%d, %d)\n", x, y);
-        return FALSE;
-    }
+	if (x > mf->width || y > mf->height) {
+		fprintf(stderr, "cell coordinates are out of the box (%d, %d)\n", x, y);
+		return FALSE;
+	}
 
-    if (mf->is_fail || mf->fully_opened)
-	    return FALSE;
+	if (mf->is_fail || mf->fully_opened)
+		return FALSE;
 
-    if (event->type == GDK_BUTTON_RELEASE) {
-	if (event->button==1 && !(event->state&GDK_BUTTON3_MASK) ) 
-	    action = ACTION_OPEN;
-	if ( ((event->button==1) && (event->state&GDK_BUTTON3_MASK))
-	    || ((event->button==3) && (event->state&GDK_BUTTON1_MASK)) ) 
-	    if (mf->opened_count!=0)
-		action = ACTION_OPEN_AROUND;
-	if (event->button==2 && mf->opened_count!=0) 
-    		action = ACTION_OPEN_AROUND;
-    }
+	if (event->type == GDK_BUTTON_RELEASE) {
+		if (event->button == 1 && !(event->state & GDK_BUTTON3_MASK))
+			action = ACTION_OPEN;
+		if (((event->button == 1) && (event->state & GDK_BUTTON3_MASK))
+		        || ((event->button == 3) && (event->state & GDK_BUTTON1_MASK)))
+			if (mf->opened_count != 0)
+				action = ACTION_OPEN_AROUND;
+		if (event->button == 2 && mf->opened_count != 0)
+			action = ACTION_OPEN_AROUND;
+	}
 
-    if (event->type == GDK_BUTTON_PRESS) {
-	if (event->button == 3)
-	    action = ACTION_MARK;
-    }
+	if (event->type == GDK_BUTTON_PRESS) {
+		if (event->button == 3)
+			action = ACTION_MARK;
+	}
 
-    if (event->type == GDK_BUTTON_PRESS
-	    || event->type == GDK_2BUTTON_PRESS
-	    || event->type == GDK_3BUTTON_PRESS) {
-	if (event->button == 2)
-		pressed_state = PRESSED_STATE_AROUND;
-	else if ( (event->button == 3) 
-		   && (event->state&GDK_BUTTON1_MASK) )
-		pressed_state = PRESSED_STATE_AROUND;
-	else if ( (event->button == 1) 
-		   && (event->state&GDK_BUTTON3_MASK) )
-		pressed_state = PRESSED_STATE_AROUND;
-	else if (event->button == 1) 
-		pressed_state = PRESSED_STATE_ALONE;
-    }
+	if (event->type == GDK_BUTTON_PRESS
+	        || event->type == GDK_2BUTTON_PRESS
+	        || event->type == GDK_3BUTTON_PRESS) {
+		if (event->button == 2)
+			pressed_state = PRESSED_STATE_AROUND;
+		else if ((event->button == 3)
+		         && (event->state & GDK_BUTTON1_MASK))
+			pressed_state = PRESSED_STATE_AROUND;
+		else if ((event->button == 1)
+		         && (event->state & GDK_BUTTON3_MASK))
+			pressed_state = PRESSED_STATE_AROUND;
+		else if (event->button == 1)
+			pressed_state = PRESSED_STATE_ALONE;
+	}
 
-    switch (action) {
+	switch (action) {
 	case ACTION_OPEN:
-	    mf_set_state(mf, x, y, OPENED);
-	    break;
+		mf_set_state(mf, x, y, OPENED);
+		break;
 	case ACTION_OPEN_AROUND:
-	    mf_set_state_around(mf, x, y, mf->cell[x][y] & OPENED);
-	    break;
+		mf_set_state_around(mf, x, y, mf->cell[x][y] & OPENED);
+		break;
 	case ACTION_MARK:
-	    mf_set_state(mf, x, y, MARKED);
-	    break;
-    }
+		mf_set_state(mf, x, y, MARKED);
+		break;
+	}
 
-    switch (pressed_state) {
+	switch (pressed_state) {
 	case PRESSED_STATE_ALONE:
-	    display_field_show_pressed(widget->window, df, 
-		     gdk_gc_new(widget->window), x, y); 
-	    break;
+		display_field_show_pressed(widget->window, df,
+		                           gdk_gc_new(widget->window), x, y);
+		break;
 	case PRESSED_STATE_AROUND:
-	    display_field_show_pressed_around(widget->window, df, 
-		     gdk_gc_new(widget->window), x, y); 
-    }
+		display_field_show_pressed_around(widget->window, df,
+		                                  gdk_gc_new(widget->window), x, y);
+	}
 
-    if (pressed_state == PRESSED_NONE)
-	display_field_show(widget->window, df, FALSE);
+	if (pressed_state == PRESSED_NONE)
+		display_field_show(widget->window, df, FALSE);
 
-    if (mf->is_fail || mf->fully_opened)
-	display_field_show(widget->window, df, TRUE);
+	if (mf->is_fail || mf->fully_opened)
+		display_field_show(widget->window, df, TRUE);
 
-    display_field_admit_state(df);
-    return FALSE;
+	display_field_admit_state(df);
+	return FALSE;
 }
 
-gboolean display_field_motion_event(GtkWidget *widget, 
-	GdkEventButton *event,
-	gpointer data)
+gboolean display_field_motion_event(GtkWidget *widget,
+                                    GdkEventButton *event,
+                                    gpointer data)
 {
- /*   gint x, y;
-    DisplayField *df;
-    MinesField *mf;
-    int pressed_state;
+	/*   gint x, y;
+	   DisplayField *df;
+	   MinesField *mf;
+	   int pressed_state;
 
-    df = data;
-    mf = df->field;
-    x = (gint)event->x/df->cell_size;
-    y = (gint)event->y/df->cell_size;
+	   df = data;
+	   mf = df->field;
+	   x = (gint)event->x/df->cell_size;
+	   y = (gint)event->y/df->cell_size;
 
-    if ( (x != prev_x) && (y != prev_y) ) {
+	   if ( (x != prev_x) && (y != prev_y) ) {
 	if (event->type == GDK_BUTTON_PRESS) {
-	    if (event->button == 1) 
+	    if (event->button == 1)
 		pressed_state = PRESSED_STATE_ALONE;
 	    if (event->button == 2)
 		pressed_state = PRESSED_STATE_AROUND;
-	    if ( (event->button == 3) 
+	    if ( (event->button == 3)
 		    && (event->state&GDK_BUTTON1_MASK) )
 		pressed_state == PRESSED_STATE_AROUND;
-	    if ( (event->button == 1) 
+	    if ( (event->button == 1)
 		    && (event->state&GDK_BUTTON3_MASK) )
 		pressed_state == PRESSED_STATE_AROUND;
 	}
-	if (prev_state == PRESSED_STATE_ALONE) 
+	if (prev_state == PRESSED_STATE_ALONE)
 	    mf_set_state(mf, prev_x, prev_y, PRESSED);
 	if (prev_state == PRESSED_STATE_AROUND)
 	    mf_set_state_around(mf, prev_x, prev_y, PRESSED);
@@ -218,214 +218,213 @@ gboolean display_field_motion_event(GtkWidget *widget,
 	prev_y = y;
 	prev_state = pressed_state;
 	display_field_refresh(widget, df);
-    }*/
-    return FALSE;
+	   }*/
+	return FALSE;
 }
 
 /* display functions */
 static gboolean display_field_show(GdkDrawable *canvas,
-       	DisplayField *df, gboolean full_update)
+                                   DisplayField *df, gboolean full_update)
 {
-    GdkGC *gc;
-    int i, j;
-    MinesField *mf;
-    GdkColor color_black;
+	GdkGC *gc;
+	int i, j;
+	MinesField *mf;
+	GdkColor color_black;
 
-    mf = df->field;
+	mf = df->field;
 
-    color_black.red = 42000;
-    color_black.blue = 41000;
-    color_black.green = 41000;
+	color_black.red = 42000;
+	color_black.blue = 41000;
+	color_black.green = 41000;
 
-    gc = gdk_gc_new(canvas);
+	gc = gdk_gc_new(canvas);
 
-    for (i=0; i<mf->width; i++) {
-		for (j=0; j<mf->height; j++) {
+	for (i = 0; i < mf->width; i++) {
+		for (j = 0; j < mf->height; j++) {
 			if (mf->cell[i][j]&NEED_UPDATE || full_update) {
-			    mf->cell[i][j] &= ~NEED_UPDATE;
-			    
-			    gdk_gc_set_rgb_fg_color(gc, &color_black);
-			    gdk_draw_rectangle(canvas, gc, FALSE, 
-				    i*df->cell_size, j*df->cell_size,
-				    df->cell_size, df->cell_size);
-		
-			    if (!(mf->is_fail)) {
-			    	
+				mf->cell[i][j] &= ~NEED_UPDATE;
+
+				gdk_gc_set_rgb_fg_color(gc, &color_black);
+				gdk_draw_rectangle(canvas, gc, FALSE,
+				                   i * df->cell_size, j * df->cell_size,
+				                   df->cell_size, df->cell_size);
+
+				if (!(mf->is_fail)) {
+
 					if (mf->cell[i][j]&OPENED) {
-					    if (mf_get_number(mf, i, j) != 0) {
+						if (mf_get_number(mf, i, j) != 0) {
 							display_field_show_number(canvas, df, gc, i, j,
-								mf_get_number(mf, i, j));
-					    } else {
-                            display_field_show_opened(canvas, df, gc, i, j);
-                        }
-					    continue;
-					} 
-		
-		    		if (mf->cell[i][j]&MARKED) {
-		    		    display_field_show_marked(canvas, df, gc, i, j); 
-				    	continue;
-					}
-		
-					display_field_show_closed(canvas, df, gc, i, j); 
-			    }
-		
-			    if (mf->is_fail) {
-			    	
-					if ( (mf->cell[i][j]&OPENED) && 
-						(mf->cell[i][j]&BOMBED) ) {
-					    display_field_show_boom(canvas, df, gc, i, j);
-					    continue;
-					}
-		
-					if ( (mf->cell[i][j]&OPENED) &&
-						   !(mf->cell[i][j]&BOMBED) ) {
-			
-					    if (mf_get_number(mf, i, j) != 0) 
-							display_field_show_number(canvas, df, gc, i, j,
-								mf_get_number(mf, i, j));
-								
-					    continue;
-					}
-		
-					if ( !(mf->cell[i][j]&OPENED) &&
-						   (mf->cell[i][j]&BOMBED) ) {
-					    display_field_show_mine(canvas, df, gc, i, j);
-					    continue;
-					}
-		
-		    		if ( (mf->cell[i][j]&MARKED) &&
-					(mf->cell[i][j]&BOMBED) ) {
-		    		    display_field_show_marked(canvas, df, gc, i, j); 
-					    continue;
-					}
-		
-		    		if ( (mf->cell[i][j]&MARKED) &&
-						!(mf->cell[i][j]&BOMBED) ) {
-			    	    gdk_gc_set_rgb_fg_color(gc, &color_black);
-		    		    gdk_draw_line(canvas, gc, i*df->cell_size, j*df->cell_size,
-					    	(i+1)*df->cell_size, (j+1)*df->cell_size);
-				    	gdk_draw_line(canvas, gc, (i+1)*df->cell_size, j*df->cell_size,
-					    	i*df->cell_size, (j+1)*df->cell_size);
-				    	continue;
-					}
-		
-					if ( !(mf->cell[i][j]&OPENED) &&
-						!(mf->cell[i][j]&BOMBED) &&
-					    !(mf->cell[i][j]&MARKED)) {
-				    	display_field_show_closed(canvas, df, gc, i, j);
-				    	continue;
+							                          mf_get_number(mf, i, j));
+						} else
+							display_field_show_opened(canvas, df, gc, i, j);
+						continue;
 					}
 
-			    }
+					if (mf->cell[i][j]&MARKED) {
+						display_field_show_marked(canvas, df, gc, i, j);
+						continue;
+					}
+
+					display_field_show_closed(canvas, df, gc, i, j);
+				}
+
+				if (mf->is_fail) {
+
+					if ((mf->cell[i][j]&OPENED) &&
+					        (mf->cell[i][j]&BOMBED)) {
+						display_field_show_boom(canvas, df, gc, i, j);
+						continue;
+					}
+
+					if ((mf->cell[i][j]&OPENED) &&
+					        !(mf->cell[i][j]&BOMBED)) {
+
+						if (mf_get_number(mf, i, j) != 0)
+							display_field_show_number(canvas, df, gc, i, j,
+							                          mf_get_number(mf, i, j));
+
+						continue;
+					}
+
+					if (!(mf->cell[i][j]&OPENED) &&
+					        (mf->cell[i][j]&BOMBED)) {
+						display_field_show_mine(canvas, df, gc, i, j);
+						continue;
+					}
+
+					if ((mf->cell[i][j]&MARKED) &&
+					        (mf->cell[i][j]&BOMBED)) {
+						display_field_show_marked(canvas, df, gc, i, j);
+						continue;
+					}
+
+					if ((mf->cell[i][j]&MARKED) &&
+					        !(mf->cell[i][j]&BOMBED)) {
+						gdk_gc_set_rgb_fg_color(gc, &color_black);
+						gdk_draw_line(canvas, gc, i * df->cell_size, j * df->cell_size,
+						              (i + 1)*df->cell_size, (j + 1)*df->cell_size);
+						gdk_draw_line(canvas, gc, (i + 1)*df->cell_size, j * df->cell_size,
+						              i * df->cell_size, (j + 1)*df->cell_size);
+						continue;
+					}
+
+					if (!(mf->cell[i][j]&OPENED) &&
+					        !(mf->cell[i][j]&BOMBED) &&
+					        !(mf->cell[i][j]&MARKED)) {
+						display_field_show_closed(canvas, df, gc, i, j);
+						continue;
+					}
+
+				}
 			}
 		}
-    }
+	}
 
-    g_object_unref(G_OBJECT(gc));
+	g_object_unref(G_OBJECT(gc));
 
-    return FALSE;
+	return FALSE;
 }
 
 void display_field_show_number(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-       	gint i, gint j, gint number)
+                               gint i, gint j, gint number)
 {
-    gdk_draw_drawable(draw, gc, pixmap_numbers[number-1], 0, 0, 
-	    (gint)i*df->cell_size+1, (gint)j*df->cell_size+1,
-	    df->cell_size-1, df->cell_size-1);
+	gdk_draw_drawable(draw, gc, pixmap_numbers[number - 1], 0, 0,
+	                  (gint)i * df->cell_size + 1, (gint)j * df->cell_size + 1,
+	                  df->cell_size - 1, df->cell_size - 1);
 }
 
 void display_field_show_closed(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j)
+                               gint i, gint j)
 {
-    display_field_show_pixmap(draw, df, gc, i, j, pixmap_closed); 
+	display_field_show_pixmap(draw, df, gc, i, j, pixmap_closed);
 }
 
 void display_field_show_opened(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j)
+                               gint i, gint j)
 {
-    display_field_show_pixmap(draw, df, gc, i, j, pixmap_opened); 
+	display_field_show_pixmap(draw, df, gc, i, j, pixmap_opened);
 }
 
 void display_field_show_marked(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j)
+                               gint i, gint j)
 {
-    display_field_show_pixmap(draw, df, gc, i, j, pixmap_marked); 
+	display_field_show_pixmap(draw, df, gc, i, j, pixmap_marked);
 }
 
 void display_field_show_boom(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j)
+                             gint i, gint j)
 {
-    display_field_show_pixmap(draw, df, gc, i, j, pixmap_boom); 
+	display_field_show_pixmap(draw, df, gc, i, j, pixmap_boom);
 }
 
 void display_field_show_mine(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j)
+                             gint i, gint j)
 {
-    display_field_show_pixmap(draw, df, gc, i, j, pixmap_mine); 
+	display_field_show_pixmap(draw, df, gc, i, j, pixmap_mine);
 }
 
 void display_field_show_pressed(GdkDrawable *draw,
-       	DisplayField *df, GdkGC *gc,
-       	gint x, gint y)
+                                DisplayField *df, GdkGC *gc,
+                                gint x, gint y)
 {
-    MinesField *mf;
+	MinesField *mf;
 
-    mf = df->field;
-    
-    if ((x<0 || x>=mf->width)
-	    || (y<0 || y>=mf->height))
+	mf = df->field;
+
+	if ((x < 0 || x >= mf->width)
+	        || (y < 0 || y >= mf->height))
 		return;
 
-    if ( !(mf->cell[x][y]&OPENED) 
-	   && !(mf->cell[x][y]&MARKED) ) {
+	if (!(mf->cell[x][y]&OPENED)
+	        && !(mf->cell[x][y]&MARKED)) {
 		mf->cell[x][y] |= NEED_UPDATE;
-		gdk_draw_drawable(draw, gc, pixmap_pressed, 0, 0, 
-			(gint)x*df->cell_size+1, (gint)y*df->cell_size+1,
-			df->cell_size-1, df->cell_size-1);
-    }
-}
-
-void display_field_show_pressed_around(GdkDrawable *draw,
-       	DisplayField *df, GdkGC *gc,
-       	gint x, gint y)
-{
-    MinesField *mf;
-    int i, j;
-
-    mf = df->field;
-    mf = df->field;
-        if ((x<0 || x>=mf->width)
-	    || (y<0 || y>=mf->height))
-	    return;
-    for (i=max(0, x-1); i<min(mf->width, x+2); i++)
-		for (j=max(0, y-1); j<min(mf->height, y+2); j++) {
-	    	if ( !(mf->cell[i][j]&OPENED) &&
-				!(mf->cell[i][j]&MARKED) ) {
-				mf->cell[i][j] |= NEED_UPDATE;
-				gdk_draw_drawable(draw, gc, pixmap_pressed, 0, 0, 
-					(gint)i*df->cell_size+1, (gint)j*df->cell_size+1,
-					df->cell_size-1, df->cell_size-1);
-	   	}
+		gdk_draw_drawable(draw, gc, pixmap_pressed, 0, 0,
+		                  (gint)x * df->cell_size + 1, (gint)y * df->cell_size + 1,
+		                  df->cell_size - 1, df->cell_size - 1);
 	}
 }
 
-void display_field_show_xpm(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j, const gchar *xpm_file)
+void display_field_show_pressed_around(GdkDrawable *draw,
+                                       DisplayField *df, GdkGC *gc,
+                                       gint x, gint y)
 {
-    GdkPixmap *pixmap;
+	MinesField *mf;
+	int i, j;
 
-    pixmap = gdk_pixmap_create_from_xpm(draw, NULL, NULL, xpm_file);
-    gdk_draw_drawable(draw, gc, pixmap, 0, 0, 
-	    (gint)i*df->cell_size+1, (gint)j*df->cell_size+1,
-	    df->cell_size-1, df->cell_size-1);
-    g_object_unref(G_OBJECT(pixmap));
+	mf = df->field;
+	mf = df->field;
+	if ((x < 0 || x >= mf->width)
+	        || (y < 0 || y >= mf->height))
+		return;
+	for (i = max(0, x - 1); i < min(mf->width, x + 2); i++)
+		for (j = max(0, y - 1); j < min(mf->height, y + 2); j++) {
+			if (!(mf->cell[i][j]&OPENED) &&
+			        !(mf->cell[i][j]&MARKED)) {
+				mf->cell[i][j] |= NEED_UPDATE;
+				gdk_draw_drawable(draw, gc, pixmap_pressed, 0, 0,
+				                  (gint)i * df->cell_size + 1, (gint)j * df->cell_size + 1,
+				                  df->cell_size - 1, df->cell_size - 1);
+			}
+		}
+}
+
+void display_field_show_xpm(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
+                            gint i, gint j, const gchar *xpm_file)
+{
+	GdkPixmap *pixmap;
+
+	pixmap = gdk_pixmap_create_from_xpm(draw, NULL, NULL, xpm_file);
+	gdk_draw_drawable(draw, gc, pixmap, 0, 0,
+	                  (gint)i * df->cell_size + 1, (gint)j * df->cell_size + 1,
+	                  df->cell_size - 1, df->cell_size - 1);
+	g_object_unref(G_OBJECT(pixmap));
 }
 
 void display_field_show_pixmap(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j, GdkPixmap *pixmap)
+                               gint i, gint j, GdkPixmap *pixmap)
 {
-    gdk_draw_drawable(draw, gc, pixmap, 0, 0, 
-	    (gint)i*df->cell_size+1, (gint)j*df->cell_size+1,
-	    df->cell_size-1, df->cell_size-1);
+	gdk_draw_drawable(draw, gc, pixmap, 0, 0,
+	                  (gint)i * df->cell_size + 1, (gint)j * df->cell_size + 1,
+	                  df->cell_size - 1, df->cell_size - 1);
 }
 

--- a/field_snapshot.c
+++ b/field_snapshot.c
@@ -31,82 +31,82 @@ static gchar *current_video = NULL;
 static gint current_video_index = 0;
 
 gboolean video_recorder_function(gpointer *data)
-{/*
-    MinesField *mf;
-    FieldSnapshot fs;
-    gint pointer_mask;
-    gint pointer_x;
-    gint pointer_y;
+{	/*
+	   MinesField *mf;
+	   FieldSnapshot fs;
+	   gint pointer_mask;
+	   gint pointer_x;
+	   gint pointer_y;
 
-    mf = (MinesField*)data;
-    if (main_window.time.tv_sec > 999
+	   mf = (MinesField*)data;
+	   if (main_window.time.tv_sec > 999
 	 || mf->fully_opened
 	 || mf->is_fail
 	 || mf->opened_count == 0) {
 	FILE *fd_test_video;
 	fd_test_video = fopen("current_test.video", "w");
-	fwrite(current_video, sizeof(FieldSnapshot), 
-	       	current_video_index+1, fd_test_video); 	
+	fwrite(current_video, sizeof(FieldSnapshot),
+	       	current_video_index+1, fd_test_video);
 	fclose(fd_test_video);
 	g_free(current_video);
 	current_video = NULL;
-       	return FALSE;    
-    }*/
-    /* Allocates memory for the next snapshot */
-/*    if (current_video == NULL) {
-	current_video = g_malloc0(sizeof(FieldSnapshot));
-	current_video_index = 0;
-    } else {
-	current_video_index++;
-	current_video = g_realloc(current_video,
-	       	(current_video_index+1)*sizeof(FieldSnapshot));
-    }
+	      	return FALSE;
+	   }*/
+	/* Allocates memory for the next snapshot */
+	/*    if (current_video == NULL) {
+		current_video = g_malloc0(sizeof(FieldSnapshot));
+		current_video_index = 0;
+	    } else {
+		current_video_index++;
+		current_video = g_realloc(current_video,
+		       	(current_video_index+1)*sizeof(FieldSnapshot));
+	    }
 
-    g_memmove((gpointer)&fs.field, (gpointer)mf, sizeof(MinesField));
-    fs.index = current_video_index;
-    fs.time.tv_sec = main_window.time.tv_sec;
-    fs.time.tv_usec = main_window.time.tv_usec;
-    gdk_window_get_pointer(main_window.df->widget->window,
-	    &pointer_x, &pointer_y, &pointer_mask);
-    fs.pointer_x = pointer_x;
-    fs.pointer_y = pointer_y;
-    fs.pointer_mask = pointer_mask;
+	    g_memmove((gpointer)&fs.field, (gpointer)mf, sizeof(MinesField));
+	    fs.index = current_video_index;
+	    fs.time.tv_sec = main_window.time.tv_sec;
+	    fs.time.tv_usec = main_window.time.tv_usec;
+	    gdk_window_get_pointer(main_window.df->widget->window,
+		    &pointer_x, &pointer_y, &pointer_mask);
+	    fs.pointer_x = pointer_x;
+	    fs.pointer_y = pointer_y;
+	    fs.pointer_mask = pointer_mask;
 
-    g_memmove((gpointer)(current_video+
-		current_video_index*sizeof(FieldSnapshot)),
-	    (gpointer)&fs, sizeof(FieldSnapshot));*/
+	    g_memmove((gpointer)(current_video+
+			current_video_index*sizeof(FieldSnapshot)),
+		    (gpointer)&fs, sizeof(FieldSnapshot));*/
 
-    return TRUE;
+	return TRUE;
 }
 
 gboolean video_player_function(gpointer *data)
 {
 }
 /*
- * filename - null terminated string which contains 
+ * filename - null terminated string which contains
  * video file name.
  */
 gboolean play_video(gchar *filename, ...)
 {
-    /*
-    FILE *fd_video;
-    FieldSnapshot fs;
-    gint ret;
-    current_video_index = 0;
-    current_video = NULL;
+	/*
+	FILE *fd_video;
+	FieldSnapshot fs;
+	gint ret;
+	current_video_index = 0;
+	current_video = NULL;
 
-    fd_video = fopen(filename, "r");
-    while (!eof(fd_video)) {
+	fd_video = fopen(filename, "r");
+	while (!eof(fd_video)) {
 	ret = fread(&fs, sizeof(FieldSnapshot), 1, fd_video);
 	if (ret != sizeof(FieldSnapshot))
 	    break;
-	current_video = g_realloc(current_video, 
+	current_video = g_realloc(current_video,
 		(current_index+1)sizeof(FieldSnapshot));
 	g_memmove((current_video+current_video_index*sizeof(FieldSnapshot)),
-	       &fs, sizeof(FieldSnapshot));	
-    }*/
-    
-    return TRUE;
+	       &fs, sizeof(FieldSnapshot));
+	}*/
+
+	return TRUE;
 }
 
 

--- a/include/display_field.h
+++ b/include/display_field.h
@@ -35,82 +35,83 @@ GdkPixmap *pixmap_mine;
 GdkPixmap *pixmap_pressed;
 GdkPixmap *pixmap_numbers[8];
 
-enum actions 
+enum actions
 {
-    ACTION_OPEN,
-    ACTION_MARK, 
-    ACTION_OPEN_AROUND, 
+	ACTION_OPEN,
+	ACTION_MARK,
+	ACTION_OPEN_AROUND,
 };
 
-enum pressed_states {
-    PRESSED_STATE_ALONE, 
-    PRESSED_STATE_AROUND,
-    PRESSED_NONE
+enum pressed_states
+{
+	PRESSED_STATE_ALONE,
+	PRESSED_STATE_AROUND,
+	PRESSED_NONE
 };
 
-typedef void (*StateHandler) (GObject*, MinesField*);
+typedef void (*StateHandler)(GObject*, MinesField*);
 
 /* data */
-typedef struct 
+typedef struct
 {
-    GtkWidget *widget; /* field display widget */
-    GObject *object; /* an object which handle field state changes */
-    StateHandler state_handler;
-    gint cell_size;
-    MinesField *field;
+	GtkWidget *widget; /* field display widget */
+	GObject *object; /* an object which handle field state changes */
+	StateHandler state_handler;
+	gint cell_size;
+	MinesField *field;
 } DisplayField;
 
 /* functions */
 DisplayField* display_field_new(MinesField *mf, GObject *object,
-       StateHandler state_handler, gint cell_size);
+                                StateHandler state_handler, gint cell_size);
 
 gboolean display_field_expose_event(GtkWidget *widget,
-        GdkEventExpose *event,
-	gpointer df);
+                                    GdkEventExpose *event,
+                                    gpointer df);
 
-gboolean display_field_button_event(GtkWidget *widget, 
-	GdkEventButton *event,
-	gpointer data);
+gboolean display_field_button_event(GtkWidget *widget,
+                                    GdkEventButton *event,
+                                    gpointer data);
 
-gboolean display_field_motion_event(GtkWidget *widget, 
-	GdkEventButton *event,
-	gpointer data);
+gboolean display_field_motion_event(GtkWidget *widget,
+                                    GdkEventButton *event,
+                                    gpointer data);
 
 static gboolean display_field_show(GdkDrawable *canvas,
-       	DisplayField *df, gboolean full_update);
+                                   DisplayField *df, gboolean full_update);
 
 void display_field_show_pressed(GdkDrawable *draw,
-       	DisplayField *df, GdkGC *gc,
-       	gint x, gint y);
+                                DisplayField *df, GdkGC *gc,
+                                gint x, gint y);
 
 void display_field_show_pressed_around(GdkDrawable *draw,
-       	DisplayField *df, GdkGC *gc,
-       	gint x, gint y);
+                                       DisplayField *df, GdkGC *gc,
+                                       gint x, gint y);
 
 void display_field_show_number(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-       	gint i, gint j, gint number);
+                               gint i, gint j, gint number);
 
 void display_field_show_closed(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j);
+                               gint i, gint j);
 
 void display_field_show_opened(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j);
+                               gint i, gint j);
 
 void display_field_show_marked(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j);
+                               gint i, gint j);
 
 void display_field_show_boom(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j);
+                             gint i, gint j);
 
 void display_field_show_mine(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j);
+                             gint i, gint j);
 
 void display_field_show_pressed(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j);
+                                gint i, gint j);
 
 void display_field_show_xpm(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j, const gchar *xpm_file);
+                            gint i, gint j, const gchar *xpm_file);
 
 void display_field_show_pixmap(GdkDrawable *draw, DisplayField *df, GdkGC *gc,
-	gint i, gint j, GdkPixmap *pixmap);
+                               gint i, gint j, GdkPixmap *pixmap);
 #endif

--- a/include/field_snapshot.h
+++ b/include/field_snapshot.h
@@ -28,12 +28,12 @@
 
 typedef struct
 {
-    MinesField field;
-    gint index; /* snapshot index */
-    GTimeVal time;
-    gint pointer_x;
-    gint pointer_y;
-    gint pointer_mask; /* GdkModifierType */
+	MinesField field;
+	gint index; /* snapshot index */
+	GTimeVal time;
+	gint pointer_x;
+	gint pointer_y;
+	gint pointer_mask; /* GdkModifierType */
 } FieldSnapshot;
 
 gboolean video_recorder_function(gpointer *data);

--- a/include/main.h
+++ b/include/main.h
@@ -27,53 +27,50 @@
 #define MAIN_H
 #include "display_field.h"
 
-enum menu_items 
+enum menu_items
 {
-    MENU_GAME_QUIT,
-    MENU_GAME_LARGE, 
-    MENU_GAME_MEDIUM,
-    MENU_GAME_SMALL, 
-    MENU_GAME_SCORES, 
-    MENU_GAME_VIDEO
+	MENU_GAME_QUIT,
+	MENU_GAME_LARGE,
+	MENU_GAME_MEDIUM,
+	MENU_GAME_SMALL,
+	MENU_GAME_SCORES,
+	MENU_GAME_VIDEO
 };
 
-enum predefined 
+enum predefined
 {
-    PREDEFINED_SMALL,
-    PREDEFINED_MEDIUM,
-    PREDEFINED_LARGE,
-    PREDEFINED_NONE
+	PREDEFINED_SMALL,
+	PREDEFINED_MEDIUM,
+	PREDEFINED_LARGE,
+	PREDEFINED_NONE
 };
 
 enum modes
 {
-    MODE_NORMAL,
-    MODE_VIDEO
+	MODE_NORMAL,
+	MODE_VIDEO
 };
 
-typedef struct 
+typedef struct
 {
-    DisplayField *df;
-    GtkWidget *widget;
-    GtkWidget *timer_widget;
-    GtkWidget *_3BV_widget;
-    GtkWidget *mines_count_widget;
-    GTimeVal time; /* game duration */
-    gint predefined_state;
-    gint mode; /* Normal or playing video mode */
+	DisplayField *df;
+	GtkWidget *widget;
+	GtkWidget *timer_widget;
+	GtkWidget *_3BV_widget;
+	GtkWidget *mines_count_widget;
+	GTimeVal time; /* game duration */
+	gint predefined_state;
+	gint mode; /* Normal or playing video mode */
 } MainWindow;
 
 typedef struct
 {
-    gint bombs;
-    gint width;
-    gint height;
-    GTimeVal small_time;
-    GTimeVal medium_time;
-    GTimeVal large_time;
+	gint bombs;
+	gint width;
+	gint height;
+	GTimeVal small_time;
+	GTimeVal medium_time;
+	GTimeVal large_time;
 } MinerConfig;
 
-
-
 #endif
-

--- a/include/mines_field.h
+++ b/include/mines_field.h
@@ -22,27 +22,27 @@
  * SOFTWARE.
  */
 
-#ifndef MINES_FIELD 
-#define MINES_FIELD 
+#ifndef MINES_FIELD
+#define MINES_FIELD
 #include <gtk/gtk.h>
 typedef enum
 {
-    BOMBED = 1,
-    OPENED = 1 << 1,
-    MARKED = 1 << 2,
-    NEED_UPDATE = 1 << 3,
+	BOMBED = 1,
+	OPENED = 1 << 1,
+	MARKED = 1 << 2,
+	NEED_UPDATE = 1 << 3,
 } SellStatus;
 
-typedef struct 
+typedef struct
 {
-    gint height;
-    gint width;
-    gint bombs;
-    gboolean is_fail;
-    gint opened_count;
-    gboolean fully_opened;
-    gint marked_count;
-    int **cell; /* matrix */
+	gint height;
+	gint width;
+	gint bombs;
+	gboolean is_fail;
+	gint opened_count;
+	gboolean fully_opened;
+	gint marked_count;
+	int **cell; /* matrix */
 } MinesField;
 
 #define max(x, y) ( (x) > (y) ? (x) : (y) )
@@ -55,20 +55,20 @@ gint mf_get_number(MinesField *mf, gint x, gint y);
 
 gint mf_get_marked(MinesField *mf, gint x, gint y);
 
-gboolean mf_set_state(MinesField *mf, 
-	gint x, gint y,
-       	SellStatus status);
+gboolean mf_set_state(MinesField *mf,
+                      gint x, gint y,
+                      SellStatus status);
 /**
  * df_set_state_around(gint x, gint y)
  *
- * set all neigours status to opened if possible 
+ * set all neigours status to opened if possible
  *
  * @param gint x
- * @param gint y 
+ * @param gint y
  */
 gboolean mf_set_state_around(MinesField *mf,
-       	gint x, gint y,
-	gint state);
+                             gint x, gint y,
+                             gint state);
 
 void mf_new_field(MinesField *mf);
 gint mf_get_3BV(MinesField *mf);

--- a/main.c
+++ b/main.c
@@ -37,16 +37,16 @@
 
 /*
  *   display_field_button_event
- * 		|
- * 	 check button state
- * 	        |
+ *              |
+ *       check button state
+ *              |
  *       change miner field
- *         	|                   
- *    refresh field representation 
+ *              |
+ *    refresh field representation
  */
 
 /*
- Constansts which contains a pixmap files names
+ * Constansts which contains a pixmap files names
  */
 
 const gchar OPENED_XPM[] = "pixmaps/opened.xpm";
@@ -55,6 +55,7 @@ const gchar CLOSED_XPM[] = "pixmaps/closed.xpm";
 const gchar BOOM_XPM[] = "pixmaps/boom.xpm";
 const gchar MINE_XPM[] = "pixmaps/mine.xpm";
 const gchar PRESSED_XPM[] = "pixmaps/pressed.xpm";
+
 /* Global variables */
 
 /* The main window widget */
@@ -62,12 +63,13 @@ static MainWindow main_window;
 /* The application current state */
 static MinerConfig miner_config;
 
-/* 
+/*
  * This array contains tokens which function read_miner_config
- * expects to meet while reading config file 
+ * expects to meet while reading config file
  */
 static const char *token[] = {"bombs", "width", "height",
-		       "small", "medium", "large"};
+                              "small", "medium", "large"
+                             };
 
 /* TOKEN_ constants contains token index in the token array */
 #define TOKEN_BOMBS  0
@@ -82,21 +84,21 @@ static const char *token[] = {"bombs", "width", "height",
 #define TOKEN_SIZE  0x100
 #define TOKEN_NUMBER  6
 
-/* 
+/*
  * Converts a double to a GTimeVal pointed by time argument
  */
 static inline void double_to_tv(GTimeVal *time, double double_val)
 {
-    time->tv_sec = (gulong)trunc(double_val);
-    time->tv_usec = (glong)trunc(1000000*(double_val - time->tv_sec));
+	time->tv_sec = (gulong)trunc(double_val);
+	time->tv_usec = (glong)trunc(1000000 * (double_val - time->tv_sec));
 }
 /*
  * Converts GTimeVal to a double and put its string representation
- * into the memory pointed by doublestr 
+ * into the memory pointed by doublestr
  */
 static inline void tv_to_doublestr(GTimeVal *time, gchar *doublestr, gint size)
 {
-    g_snprintf(doublestr, size, "%lu.%lu", time->tv_sec, time->tv_usec);
+	g_snprintf(doublestr, size, "%lu.%lu", time->tv_sec, time->tv_usec);
 }
 /*
  * The fields has a three predefined states. It is a small 8x8x10,
@@ -106,211 +108,210 @@ static inline void tv_to_doublestr(GTimeVal *time, gchar *doublestr, gint size)
  */
 static inline void set_predefined_state(MainWindow *main_window, MinerConfig *config)
 {
-    main_window->predefined_state = PREDEFINED_NONE;
-    if (config->bombs == 10 &&
-	    config->width == 8 &&
-	    config->height == 8)
-	main_window->predefined_state = PREDEFINED_SMALL;
-    if (config->bombs == 40 &&
-	    config->width == 16 &&
-	    config->height == 16)
-	main_window->predefined_state = PREDEFINED_MEDIUM;
-    if (config->bombs == 99 &&
-	    config->width == 30 &&
-	    config->height == 16)
-	main_window->predefined_state = PREDEFINED_LARGE;
+	main_window->predefined_state = PREDEFINED_NONE;
+	if (config->bombs == 10 &&
+	        config->width == 8 &&
+	        config->height == 8)
+		main_window->predefined_state = PREDEFINED_SMALL;
+	if (config->bombs == 40 &&
+	        config->width == 16 &&
+	        config->height == 16)
+		main_window->predefined_state = PREDEFINED_MEDIUM;
+	if (config->bombs == 99 &&
+	        config->width == 30 &&
+	        config->height == 16)
+		main_window->predefined_state = PREDEFINED_LARGE;
 }
 
-/* 
+/*
  * Sets predefined state of the field using main_window
  * argument. It means is sets a width, height and number
- * of bumbs which correspond to the predefined state.
+ * of bombs which correspond to the predefined state.
  */
-static inline gboolean set_predefined_time(MinerConfig *config, 
-	MainWindow *main_window)
+static inline gboolean set_predefined_time(MinerConfig *config,
+        MainWindow *main_window)
 {
-    GTimeVal *time;
-    gboolean new_record;
+	GTimeVal *time;
+	gboolean new_record;
 
-    time = &main_window->time;
-    new_record = FALSE;
-    switch (main_window->predefined_state) {
+	time = &main_window->time;
+	new_record = FALSE;
+	switch (main_window->predefined_state) {
 	case PREDEFINED_SMALL:
-	    if (config->small_time.tv_sec > time->tv_sec ||
-		    ((config->small_time.tv_usec > time->tv_usec) 
-		     && (config->small_time.tv_sec == time->tv_sec))) {
-		config->small_time.tv_sec = time->tv_sec;  
-		config->small_time.tv_usec = time->tv_usec;  
-		new_record = TRUE;
-	    }
-	    break;
+		if (config->small_time.tv_sec > time->tv_sec ||
+		        ((config->small_time.tv_usec > time->tv_usec)
+		         && (config->small_time.tv_sec == time->tv_sec))) {
+			config->small_time.tv_sec = time->tv_sec;
+			config->small_time.tv_usec = time->tv_usec;
+			new_record = TRUE;
+		}
+		break;
 	case PREDEFINED_MEDIUM:
-	    if (config->medium_time.tv_sec >= time->tv_sec ||
-		    ((config->medium_time.tv_usec > time->tv_usec)
-		     && (config->medium_time.tv_sec == time->tv_sec))) {
-		config->medium_time.tv_sec = time->tv_sec;  
-		config->medium_time.tv_usec = time->tv_usec;  
-		new_record = TRUE;
-	    }
-	    break;
+		if (config->medium_time.tv_sec >= time->tv_sec ||
+		        ((config->medium_time.tv_usec > time->tv_usec)
+		         && (config->medium_time.tv_sec == time->tv_sec))) {
+			config->medium_time.tv_sec = time->tv_sec;
+			config->medium_time.tv_usec = time->tv_usec;
+			new_record = TRUE;
+		}
+		break;
 	case PREDEFINED_LARGE:
-	    if (config->large_time.tv_sec >= time->tv_sec ||
-		    ((config->large_time.tv_usec > time->tv_usec)
-		     && (config->large_time.tv_sec == time->tv_sec))) {
-		config->large_time.tv_sec = time->tv_sec;  
-		config->large_time.tv_usec = time->tv_usec;  
-		new_record = TRUE;
-	    }
-	    break;
-    }
-    return new_record;
+		if (config->large_time.tv_sec >= time->tv_sec ||
+		        ((config->large_time.tv_usec > time->tv_usec)
+		         && (config->large_time.tv_sec == time->tv_sec))) {
+			config->large_time.tv_sec = time->tv_sec;
+			config->large_time.tv_usec = time->tv_usec;
+			new_record = TRUE;
+		}
+		break;
+	}
+	return new_record;
 }
-/* 
+/*
  * Sets default config state if somthing goes wrong
  * while reading setting from config file
  */
 void init_miner_config(MinerConfig *config)
 {
-    config->bombs = 10;
-    config->width = 8;
-    config->height = 8;
-    config->small_time.tv_sec = 999;
-    config->small_time.tv_usec = 0;
-    config->medium_time.tv_sec = 999;
-    config->medium_time.tv_usec = 0;
-    config->large_time.tv_sec = 999;
-    config->large_time.tv_usec = 0;
+	config->bombs = 10;
+	config->width = 8;
+	config->height = 8;
+	config->small_time.tv_sec = 999;
+	config->small_time.tv_usec = 0;
+	config->medium_time.tv_sec = 999;
+	config->medium_time.tv_usec = 0;
+	config->large_time.tv_sec = 999;
+	config->large_time.tv_usec = 0;
 }
 
-/* 
- * Reads initial configuration 
+/*
+ * Reads initial configuration
  * and feels a MinerConfig structure.
  */
 gboolean read_miner_conifg(MinerConfig *config)
 {
-    FILE *fd_config;
-    gchar current_line[LINE_SIZE];
-    gchar current_token[TOKEN_SIZE];
-    gchar current_token_value[TOKEN_SIZE];
-    gint line_pos=0;
-    gint pos=0;
-    gint i=0;
-    double double_val;;
+	FILE *fd_config;
+	gchar current_line[LINE_SIZE];
+	gchar current_token[TOKEN_SIZE];
+	gchar current_token_value[TOKEN_SIZE];
+	gint line_pos = 0;
+	gint pos = 0;
+	gint i = 0;
+	double double_val;;
 
-    /* At first set miner config to default values if 
-     * somthing well goes wrong with config file */
-    init_miner_config(config);
-    fd_config = fopen(".miner", "r");
-    if (fd_config == NULL) {
-        return FALSE;
-    }
-    while (!feof(fd_config)) {
-        fgets(current_line, LINE_SIZE, fd_config);
-        line_pos = 0;
-        pos = 0;
-        /* remove spaces before */
-        while (current_line[line_pos]==0x20 && line_pos<LINE_SIZE) 
-            line_pos++;
-        while (current_line[line_pos]!=0x20 
-                && line_pos<LINE_SIZE
-                && pos<TOKEN_SIZE
-                && current_line[line_pos]
-                && current_line[line_pos]!='\n') {
-            current_token[pos] = current_line[line_pos];
-            pos++;
-            line_pos++;
-        }
-        current_token[pos] = '\0';
-        while (current_line[line_pos]==0x20 && line_pos<LINE_SIZE)
-            line_pos++;
-        pos = 0;
-        while (current_line[line_pos]!=0x20 
-                && line_pos<LINE_SIZE
-                && pos<TOKEN_SIZE
-                && current_line[line_pos]
-                && current_line[line_pos]!='\n') {
-            current_token_value[pos] = current_line[line_pos];
-            line_pos++;
-            pos++;
-        }
-        current_token_value[pos] = '\0';
-        for (i=0; i<TOKEN_NUMBER; i++)
-            if (!g_ascii_strcasecmp(token[i], current_token)) {
-                switch(i) {
-                    case TOKEN_BOMBS:
-                        config->bombs = atoi(current_token_value);
-                        break;
-                    case TOKEN_HEIGHT:
-                        config->height = atoi(current_token_value);
-                        break;
-                    case TOKEN_WIDTH:
-                        config->width = atoi(current_token_value);
-                        break;
-                    case TOKEN_SMALL_TIME:
-                        double_val = strtod(current_token_value, NULL);
-                        double_to_tv(&config->small_time, double_val);
-                        break;
-                    case TOKEN_MEDIUM_TIME:
-                        double_val = strtod(current_token_value, NULL);
-                        double_to_tv(&config->medium_time, double_val);
-                        break;
-                    case TOKEN_LARGE_TIME:
-                        double_val = strtod(current_token_value, NULL);
-                        double_to_tv(&config->large_time, double_val);
-                        break;
-                }
-            }
-    }
-    fclose(fd_config);
-    return TRUE;
+	/* At first set miner config to default values if
+	 * somthing well goes wrong with config file */
+	init_miner_config(config);
+	fd_config = fopen(".miner", "r");
+	if (fd_config == NULL)
+		return FALSE;
+	while (!feof(fd_config)) {
+		fgets(current_line, LINE_SIZE, fd_config);
+		line_pos = 0;
+		pos = 0;
+		/* remove spaces before */
+		while (current_line[line_pos] == 0x20 && line_pos < LINE_SIZE)
+			line_pos++;
+		while (current_line[line_pos] != 0x20
+		        && line_pos < LINE_SIZE
+		        && pos < TOKEN_SIZE
+		        && current_line[line_pos]
+		        && current_line[line_pos] != '\n') {
+			current_token[pos] = current_line[line_pos];
+			pos++;
+			line_pos++;
+		}
+		current_token[pos] = '\0';
+		while (current_line[line_pos] == 0x20 && line_pos < LINE_SIZE)
+			line_pos++;
+		pos = 0;
+		while (current_line[line_pos] != 0x20
+		        && line_pos < LINE_SIZE
+		        && pos < TOKEN_SIZE
+		        && current_line[line_pos]
+		        && current_line[line_pos] != '\n') {
+			current_token_value[pos] = current_line[line_pos];
+			line_pos++;
+			pos++;
+		}
+		current_token_value[pos] = '\0';
+		for (i = 0; i < TOKEN_NUMBER; i++)
+			if (!g_ascii_strcasecmp(token[i], current_token)) {
+				switch (i) {
+				case TOKEN_BOMBS:
+					config->bombs = atoi(current_token_value);
+					break;
+				case TOKEN_HEIGHT:
+					config->height = atoi(current_token_value);
+					break;
+				case TOKEN_WIDTH:
+					config->width = atoi(current_token_value);
+					break;
+				case TOKEN_SMALL_TIME:
+					double_val = strtod(current_token_value, NULL);
+					double_to_tv(&config->small_time, double_val);
+					break;
+				case TOKEN_MEDIUM_TIME:
+					double_val = strtod(current_token_value, NULL);
+					double_to_tv(&config->medium_time, double_val);
+					break;
+				case TOKEN_LARGE_TIME:
+					double_val = strtod(current_token_value, NULL);
+					double_to_tv(&config->large_time, double_val);
+					break;
+				}
+			}
+	}
+	fclose(fd_config);
+	return TRUE;
 }
 
 /* Saves current miner configuration */
 gboolean write_miner_config(MinerConfig *config)
 {
-    gint i=0;
-    gchar current_line[LINE_SIZE];
-    gint current_pos;
-    gint value;
-    gchar str_value[0x10];
-    FILE *fd_config;
+	gint i = 0;
+	gchar current_line[LINE_SIZE];
+	gint current_pos;
+	gint value;
+	gchar str_value[0x10];
+	FILE *fd_config;
 
-    fd_config = fopen(".miner", "w");
+	fd_config = fopen(".miner", "w");
 
-    for (i=0; i<TOKEN_NUMBER; i++) {
-        current_pos = g_strlcpy(current_line, token[i], LINE_SIZE);
-        current_line[current_pos++] = 0x20;
-        switch (i) {
-            case TOKEN_BOMBS:
-                value = config->bombs;
-                g_sprintf(str_value, "%d", value); 
-                break;
-            case TOKEN_HEIGHT:
-                value = config->height;
-                g_sprintf(str_value, "%d", value); 
-                break;
-            case TOKEN_WIDTH:
-                value = config->width;
-                g_sprintf(str_value, "%d", value); 
-                break;
-            case TOKEN_SMALL_TIME:
-                tv_to_doublestr(&config->small_time, str_value, 0x10); 	
-                break;
-            case TOKEN_MEDIUM_TIME:
-                tv_to_doublestr(&config->medium_time, str_value, 0x10); 	
-                break;
-            case TOKEN_LARGE_TIME:
-                tv_to_doublestr(&config->large_time, str_value, 0x10); 	
-                break;
-        }
-        current_pos += g_strlcpy((gchar*)&current_line[current_pos],
-                str_value, LINE_SIZE);
-        current_line[current_pos++] = '\n';
-        current_line[current_pos] = '\0';
-        fputs(current_line, fd_config);
-    }
-    fclose(fd_config);
-    return TRUE;
+	for (i = 0; i < TOKEN_NUMBER; i++) {
+		current_pos = g_strlcpy(current_line, token[i], LINE_SIZE);
+		current_line[current_pos++] = 0x20;
+		switch (i) {
+		case TOKEN_BOMBS:
+			value = config->bombs;
+			g_sprintf(str_value, "%d", value);
+			break;
+		case TOKEN_HEIGHT:
+			value = config->height;
+			g_sprintf(str_value, "%d", value);
+			break;
+		case TOKEN_WIDTH:
+			value = config->width;
+			g_sprintf(str_value, "%d", value);
+			break;
+		case TOKEN_SMALL_TIME:
+			tv_to_doublestr(&config->small_time, str_value, 0x10);
+			break;
+		case TOKEN_MEDIUM_TIME:
+			tv_to_doublestr(&config->medium_time, str_value, 0x10);
+			break;
+		case TOKEN_LARGE_TIME:
+			tv_to_doublestr(&config->large_time, str_value, 0x10);
+			break;
+		}
+		current_pos += g_strlcpy((gchar*)&current_line[current_pos],
+		                         str_value, LINE_SIZE);
+		current_line[current_pos++] = '\n';
+		current_line[current_pos] = '\0';
+		fputs(current_line, fd_config);
+	}
+	fclose(fd_config);
+	return TRUE;
 }
 
 
@@ -318,55 +319,55 @@ gboolean write_miner_config(MinerConfig *config)
 /*
  * Destroy event handeler
  */
-static void main_destroy(GtkWidget *widget, 
-        GdkEvent *event,
-        gpointer data)
+static void main_destroy(GtkWidget *widget,
+                         GdkEvent *event,
+                         gpointer data)
 {
-    write_miner_config(&miner_config);
-    gtk_main_quit();
+	write_miner_config(&miner_config);
+	gtk_main_quit();
 }
 
-/* 
+/*
  * Just show current game duration time.
  * Called "almost" every 1/500 sec.
  */
 GTimeVal start_time;
 gboolean timer_function(gpointer *data)
 {
-    char timer_string[0x10];
-    timer_string[0xF] = 0;
-    gint second;
-    gint dec_second;
-    MinesField *mf;
-    GTimeVal current_time;
+	char timer_string[0x10];
+	timer_string[0xF] = 0;
+	gint second;
+	gint dec_second;
+	MinesField *mf;
+	GTimeVal current_time;
 
-    mf = (MinesField*)data;
-    if (main_window.time.tv_sec > 999
-            || mf->fully_opened
-            || mf->is_fail
-            || mf->opened_count == 0)
-        return FALSE;
+	mf = (MinesField*)data;
+	if (main_window.time.tv_sec > 999
+	        || mf->fully_opened
+	        || mf->is_fail
+	        || mf->opened_count == 0)
+		return FALSE;
 
-    if (main_window.time.tv_sec==0
-            && main_window.time.tv_usec==0) 
-        g_get_current_time(&start_time); 
+	if (main_window.time.tv_sec == 0
+	        && main_window.time.tv_usec == 0)
+		g_get_current_time(&start_time);
 
-    g_get_current_time(&current_time);
-    main_window.time.tv_sec = current_time.tv_sec - start_time.tv_sec;
-    main_window.time.tv_usec = current_time.tv_usec - start_time.tv_usec;
+	g_get_current_time(&current_time);
+	main_window.time.tv_sec = current_time.tv_sec - start_time.tv_sec;
+	main_window.time.tv_usec = current_time.tv_usec - start_time.tv_usec;
 
-    if (main_window.time.tv_usec<0) {
-        main_window.time.tv_sec--;
-        main_window.time.tv_usec = 1000000 + main_window.time.tv_usec;
-    }
+	if (main_window.time.tv_usec < 0) {
+		main_window.time.tv_sec--;
+		main_window.time.tv_usec = 1000000 + main_window.time.tv_usec;
+	}
 
-    second = main_window.time.tv_sec;
-    dec_second = main_window.time.tv_usec/10000;
-    g_sprintf(timer_string, "%3.3d:%2.2d", second, dec_second);
-    gtk_label_set_text(GTK_LABEL(main_window.timer_widget),
-            timer_string);
+	second = main_window.time.tv_sec;
+	dec_second = main_window.time.tv_usec / 10000;
+	g_sprintf(timer_string, "%3.3d:%2.2d", second, dec_second);
+	gtk_label_set_text(GTK_LABEL(main_window.timer_widget),
+	                   timer_string);
 
-    return TRUE;
+	return TRUE;
 }
 
 /*
@@ -380,325 +381,325 @@ gboolean timer_function(gpointer *data)
  * inform player about a changes.
  */
 void field_change_status_handler(GObject *widget,
-        MinesField *mf)
+                                 MinesField *mf)
 {
-    char string[0x10];
+	char string[0x10];
 
-    if (mf->is_fail) 
-        gtk_label_set_text(GTK_LABEL(widget), "FAIL");
+	if (mf->is_fail)
+		gtk_label_set_text(GTK_LABEL(widget), "FAIL");
 
-    if (mf->fully_opened) {
-        gtk_label_set_text(GTK_LABEL(widget), "OPENED");
-        if (set_predefined_time(&miner_config, &main_window))
-            gtk_label_set_text(GTK_LABEL(widget), "RECORD!");
-    }
+	if (mf->fully_opened) {
+		gtk_label_set_text(GTK_LABEL(widget), "OPENED");
+		if (set_predefined_time(&miner_config, &main_window))
+			gtk_label_set_text(GTK_LABEL(widget), "RECORD!");
+	}
 
-    if (mf->opened_count == 0) 
-        gtk_label_set_text(GTK_LABEL(widget), "READY");
+	if (mf->opened_count == 0)
+		gtk_label_set_text(GTK_LABEL(widget), "READY");
 
-    if (mf->opened_count>0 && !mf->is_fail && !mf->fully_opened
-            && main_window.time.tv_sec == 0 
-            && main_window.time.tv_usec == 0) {
-        sprintf(string, "3BV: %3.3d", mf_get_3BV(mf));
-        gtk_label_set_text(GTK_LABEL(main_window._3BV_widget), string);
-        g_timeout_add(5, (GSourceFunc)timer_function, (gpointer)mf);
-        g_timeout_add(40, (GSourceFunc)video_recorder_function, (gpointer)mf);
-    }
+	if (mf->opened_count > 0 && !mf->is_fail && !mf->fully_opened
+	        && main_window.time.tv_sec == 0
+	        && main_window.time.tv_usec == 0) {
+		sprintf(string, "3BV: %3.3d", mf_get_3BV(mf));
+		gtk_label_set_text(GTK_LABEL(main_window._3BV_widget), string);
+		g_timeout_add(5, (GSourceFunc)timer_function, (gpointer)mf);
+		g_timeout_add(40, (GSourceFunc)video_recorder_function, (gpointer)mf);
+	}
 
-    if (mf->opened_count>0 && !mf->is_fail
-            && !mf->fully_opened) {
-        sprintf(string, "M: %2.2d", mf->bombs-mf->marked_count);
-        gtk_label_set_text(GTK_LABEL(main_window.mines_count_widget), string);
-    }
+	if (mf->opened_count > 0 && !mf->is_fail
+	        && !mf->fully_opened) {
+		sprintf(string, "M: %2.2d", mf->bombs - mf->marked_count);
+		gtk_label_set_text(GTK_LABEL(main_window.mines_count_widget), string);
+	}
 }
 
 /* New button handler */
-gboolean button_new_field_pressed(GtkWidget *widget, 
-        gpointer data)
+gboolean button_new_field_pressed(GtkWidget *widget,
+                                  gpointer data)
 {
-    DisplayField *df;
-    MinesField *mf;
+	DisplayField *df;
+	MinesField *mf;
 
-    df = (DisplayField*)data;
-    main_window.time.tv_sec = 0;
-    main_window.time.tv_usec = 0;
-    gtk_label_set_text(GTK_LABEL(main_window.timer_widget), "000:00");
-    gtk_label_set_text(GTK_LABEL(main_window._3BV_widget), "3BV: ---");
-    gtk_label_set_text(GTK_LABEL(main_window.mines_count_widget), "M: ---");
-    mf_new(df->field, 
-            df->field->width,
-            df->field->height,
-            df->field->bombs);
-    gdk_window_invalidate_rect(df->widget->window, NULL, FALSE);
-    field_change_status_handler(G_OBJECT(df->object), df->field);
+	df = (DisplayField*)data;
+	main_window.time.tv_sec = 0;
+	main_window.time.tv_usec = 0;
+	gtk_label_set_text(GTK_LABEL(main_window.timer_widget), "000:00");
+	gtk_label_set_text(GTK_LABEL(main_window._3BV_widget), "3BV: ---");
+	gtk_label_set_text(GTK_LABEL(main_window.mines_count_widget), "M: ---");
+	mf_new(df->field,
+	       df->field->width,
+	       df->field->height,
+	       df->field->bombs);
+	gdk_window_invalidate_rect(df->widget->window, NULL, FALSE);
+	field_change_status_handler(G_OBJECT(df->object), df->field);
 }
 
 /* Menu handler */
-void menu_handler(GtkMenuItem *menuitem, 
-        gpointer data)
+void menu_handler(GtkMenuItem *menuitem,
+                  gpointer data)
 {
-    DisplayField *df;
-    GtkWidget *dialog;
-    gboolean is_field_state_changed = FALSE;
+	DisplayField *df;
+	GtkWidget *dialog;
+	gboolean is_field_state_changed = FALSE;
 
-    df = main_window.df;
-    switch ((enum menu_items)data) {
-        case MENU_GAME_QUIT:
-            write_miner_config(&miner_config);
-            gtk_main_quit();
-            break;
-        case MENU_GAME_SCORES:
-            dialog = create_window_score(&miner_config);
-            gtk_widget_show(dialog);
-            break;
-        case MENU_GAME_LARGE:
-            mf_new(df->field, 30, 16, 99);
-            miner_config.width = 30;
-            miner_config.height = 16;
-            miner_config.bombs = 99;
-            is_field_state_changed = TRUE; 
-            break;
-        case MENU_GAME_MEDIUM:
-            mf_new(df->field, 16, 16, 40);
-            miner_config.width = 16;
-            miner_config.height = 16;
-            miner_config.bombs = 40;
-            is_field_state_changed = TRUE; 
-            break;
-        case MENU_GAME_SMALL:
-            mf_new(df->field, 8, 8, 10);
-            miner_config.width = 8;
-            miner_config.height = 8;
-            miner_config.bombs = 10;
-            is_field_state_changed = TRUE; 
-            break;
-        case MENU_GAME_VIDEO:
-            g_print("Choose video\n");
-            GtkWidget *choose_file_dialog;
+	df = main_window.df;
+	switch ((enum menu_items)data) {
+	case MENU_GAME_QUIT:
+		write_miner_config(&miner_config);
+		gtk_main_quit();
+		break;
+	case MENU_GAME_SCORES:
+		dialog = create_window_score(&miner_config);
+		gtk_widget_show(dialog);
+		break;
+	case MENU_GAME_LARGE:
+		mf_new(df->field, 30, 16, 99);
+		miner_config.width = 30;
+		miner_config.height = 16;
+		miner_config.bombs = 99;
+		is_field_state_changed = TRUE;
+		break;
+	case MENU_GAME_MEDIUM:
+		mf_new(df->field, 16, 16, 40);
+		miner_config.width = 16;
+		miner_config.height = 16;
+		miner_config.bombs = 40;
+		is_field_state_changed = TRUE;
+		break;
+	case MENU_GAME_SMALL:
+		mf_new(df->field, 8, 8, 10);
+		miner_config.width = 8;
+		miner_config.height = 8;
+		miner_config.bombs = 10;
+		is_field_state_changed = TRUE;
+		break;
+	case MENU_GAME_VIDEO:
+		g_print("Choose video\n");
+		GtkWidget *choose_file_dialog;
 
-            choose_file_dialog = gtk_file_chooser_dialog_new("Open File",
-                    (GtkWindow *)main_window.widget,
-                    GTK_FILE_CHOOSER_ACTION_OPEN,
-                    GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                    GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
-                    NULL);
-            if (gtk_dialog_run(GTK_DIALOG(choose_file_dialog)) ==
-                    GTK_RESPONSE_ACCEPT) {
-                gchar *filename;
-                filename = gtk_file_chooser_get_filename(
-                        GTK_FILE_CHOOSER(choose_file_dialog));
-                g_print("file: %s\n", filename);
-                g_free(filename);
-            }
-            gtk_widget_destroy(choose_file_dialog);
-            break;
-    }
+		choose_file_dialog = gtk_file_chooser_dialog_new("Open File",
+		                     (GtkWindow *)main_window.widget,
+		                     GTK_FILE_CHOOSER_ACTION_OPEN,
+		                     GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+		                     GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
+		                     NULL);
+		if (gtk_dialog_run(GTK_DIALOG(choose_file_dialog)) ==
+		        GTK_RESPONSE_ACCEPT) {
+			gchar *filename;
+			filename = gtk_file_chooser_get_filename(
+			               GTK_FILE_CHOOSER(choose_file_dialog));
+			g_print("file: %s\n", filename);
+			g_free(filename);
+		}
+		gtk_widget_destroy(choose_file_dialog);
+		break;
+	}
 
-    if (is_field_state_changed) {
-        gtk_label_set_text(GTK_LABEL(main_window.timer_widget), "000:00");
-        gtk_label_set_text(GTK_LABEL(main_window._3BV_widget), "3BV: ---");
-        gtk_label_set_text(GTK_LABEL(main_window.mines_count_widget), "M: ---");
-        set_predefined_state(&main_window, &miner_config);
-        main_window.time.tv_sec = 0;
-        main_window.time.tv_usec = 0;
-        gdk_window_invalidate_rect(df->widget->window, NULL, FALSE);
-        field_change_status_handler(df->object, df->field);
-        gtk_window_resize(GTK_WINDOW(main_window.widget), 
-                df->field->width*df->cell_size,
-                df->field->height*df->cell_size);
-        gtk_widget_set_size_request(df->widget, 
-                df->cell_size*df->field->width,
-                df->cell_size*df->field->height); 
-    }
+	if (is_field_state_changed) {
+		gtk_label_set_text(GTK_LABEL(main_window.timer_widget), "000:00");
+		gtk_label_set_text(GTK_LABEL(main_window._3BV_widget), "3BV: ---");
+		gtk_label_set_text(GTK_LABEL(main_window.mines_count_widget), "M: ---");
+		set_predefined_state(&main_window, &miner_config);
+		main_window.time.tv_sec = 0;
+		main_window.time.tv_usec = 0;
+		gdk_window_invalidate_rect(df->widget->window, NULL, FALSE);
+		field_change_status_handler(df->object, df->field);
+		gtk_window_resize(GTK_WINDOW(main_window.widget),
+		                  df->field->width * df->cell_size,
+		                  df->field->height * df->cell_size);
+		gtk_widget_set_size_request(df->widget,
+		                            df->cell_size * df->field->width,
+		                            df->cell_size * df->field->height);
+	}
 }
 
 int main(int argc, char *argv[])
-{    
-    GtkWidget *window;
-    GtkWidget *container;
-    GtkWidget *hbox_top;
-    GtkWidget *hbox_bottom;
-    GtkWidget *button_new;
-    GtkWidget *label_field_state;
-    GtkWidget *label_timer;
-    GtkWidget *label_3BV;
-    GtkWidget *label_mines_count;
-    gint signal_id;
+{
+	GtkWidget *window;
+	GtkWidget *container;
+	GtkWidget *hbox_top;
+	GtkWidget *hbox_bottom;
+	GtkWidget *button_new;
+	GtkWidget *label_field_state;
+	GtkWidget *label_timer;
+	GtkWidget *label_3BV;
+	GtkWidget *label_mines_count;
+	gint signal_id;
 
-    GtkWidget *menu_container;
-    GtkWidget *menu_bar, *menu_game;
-    GtkWidget *game_menu, *game_quit, *game_large, *game_medium, *game_small,
-              *game_scores, *game_video;
+	GtkWidget *menu_container;
+	GtkWidget *menu_bar, *menu_game;
+	GtkWidget *game_menu, *game_quit, *game_large, *game_medium, *game_small,
+	          *game_scores, *game_video;
 
-    GValue *value;
+	GValue *value;
 
-    MinesField *mines_field;
-    DisplayField *display_field;
-    GdkDrawable *draw;
-    gint i;
-    gchar xpm_file_name[0x100];
-
-
-    read_miner_conifg(&miner_config);
-
-    gtk_init(&argc, &argv);
-
-    /* create main window */
-    window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_window_set_title(GTK_WINDOW(window), "Miner");
-    g_signal_connect(G_OBJECT(window), "delete_event",
-            G_CALLBACK(main_destroy), NULL);
-    g_signal_connect(G_OBJECT(window), "destroy",
-            G_CALLBACK(main_destroy), NULL);
-
-    gtk_container_set_border_width(GTK_CONTAINER(window), 10);
-    value = g_malloc0(sizeof(GValue));
-
-    g_value_init(value, G_TYPE_BOOLEAN);
-    g_value_set_boolean(value, FALSE);
-    g_object_set_property(G_OBJECT(window), "resizable", value);
-
-    /* add main container */
-    gtk_vbox_new(TRUE, 0);
-
-    container = gtk_vbox_new(FALSE, 0);
-    gtk_container_add(GTK_CONTAINER(window), container);
-
-    /* box for top panel */
-    hbox_top = gtk_hbox_new(TRUE, 0);
-
-    /* box for bottom panel */
-    hbox_bottom = gtk_hbox_new(TRUE, 0);
-
-    /* create field status indicator label */
-    label_field_state = gtk_label_new("READY");
-    gtk_box_pack_end(GTK_BOX(hbox_top), label_field_state, 
-            FALSE, FALSE, 0);
-
-    /* create field */
-    mines_field = mf_new(NULL, miner_config.width, 
-            miner_config.height, miner_config.bombs);
-
-    /* create display field field */
-    display_field = display_field_new(mines_field, 
-            G_OBJECT(label_field_state), 
-            field_change_status_handler, 20);
-
-    /* create button new*/
-    button_new = gtk_button_new_with_label("NEW");
-    gtk_box_pack_end(GTK_BOX(hbox_top), button_new,
-            FALSE, FALSE, 0);
-    g_signal_connect(G_OBJECT(button_new), "clicked",
-            G_CALLBACK(button_new_field_pressed), display_field);
-
-    /* create mines count */
-    label_mines_count = gtk_label_new("M: --");
-    gtk_box_pack_end(GTK_BOX(hbox_top), label_mines_count, 
-            FALSE, FALSE, 0);
-
-    /* create timer */
-    label_timer = gtk_label_new("000:00");
-    gtk_box_pack_end(GTK_BOX(hbox_bottom), label_timer, 
-            FALSE, FALSE, 0);
-
-    /* create 3BV */
-    label_3BV = gtk_label_new("3BV: ---");
-    gtk_box_pack_end(GTK_BOX(hbox_bottom), label_3BV, 
-            FALSE, FALSE, 0);
+	MinesField *mines_field;
+	DisplayField *display_field;
+	GdkDrawable *draw;
+	gint i;
+	gchar xpm_file_name[0x100];
 
 
-    /* construct menu*/
-    game_menu = gtk_menu_new();
-    game_small = gtk_menu_item_new_with_label("Small");
-    game_quit = gtk_menu_item_new_with_label("Quit");
-    game_large = gtk_menu_item_new_with_label("Large");
-    game_medium = gtk_menu_item_new_with_label("Medium");
-    game_scores = gtk_menu_item_new_with_label("Scores");
-    game_video = gtk_menu_item_new_with_label("Play video");
+	read_miner_conifg(&miner_config);
 
-    gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_small);
-    gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_medium);
-    gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_large);
-    gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_video);
-    gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_scores);
-    gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_quit);
+	gtk_init(&argc, &argv);
 
-    g_signal_connect(G_OBJECT(game_small), "activate",
-            G_CALLBACK(menu_handler), (gpointer)MENU_GAME_SMALL);
-    g_signal_connect(G_OBJECT(game_quit), "activate",
-            G_CALLBACK(menu_handler), (gpointer)MENU_GAME_QUIT);
-    g_signal_connect(G_OBJECT(game_large),"activate",
-            G_CALLBACK(menu_handler), (gpointer)MENU_GAME_LARGE);
-    g_signal_connect(G_OBJECT(game_medium), "activate",
-            G_CALLBACK(menu_handler), (gpointer)MENU_GAME_MEDIUM);
-    g_signal_connect(G_OBJECT(game_video), "activate",
-            G_CALLBACK(menu_handler), (gpointer)MENU_GAME_VIDEO);
-    g_signal_connect(G_OBJECT(game_scores), "activate",
-            G_CALLBACK(menu_handler), (gpointer)MENU_GAME_SCORES);
+	/* create main window */
+	window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+	gtk_window_set_title(GTK_WINDOW(window), "Miner");
+	g_signal_connect(G_OBJECT(window), "delete_event",
+	                 G_CALLBACK(main_destroy), NULL);
+	g_signal_connect(G_OBJECT(window), "destroy",
+	                 G_CALLBACK(main_destroy), NULL);
 
-    menu_bar = gtk_menu_bar_new();
-    menu_game = gtk_menu_item_new_with_label("Game");
-    gtk_menu_item_set_submenu(GTK_MENU_ITEM(menu_game), game_menu);
-    gtk_menu_bar_append(GTK_MENU_BAR(menu_bar), menu_game);
+	gtk_container_set_border_width(GTK_CONTAINER(window), 10);
+	value = g_malloc0(sizeof(GValue));
 
-    /* pack widgets into main container */
-    gtk_box_pack_start(GTK_BOX(container), menu_bar, TRUE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(container), hbox_top, FALSE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(container), display_field->widget, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(container), hbox_bottom, FALSE, TRUE, 0);
+	g_value_init(value, G_TYPE_BOOLEAN);
+	g_value_set_boolean(value, FALSE);
+	g_object_set_property(G_OBJECT(window), "resizable", value);
 
-    /* set sizes */
-    /* gtk_widget_set_size_request(window, 
-       mines_field->width*display_field->cell_size+40,
-       mines_field->height*display_field->cell_size+150); 
-       gtk_widget_set_size_request(button_new, 60, 32); */
+	/* add main container */
+	gtk_vbox_new(TRUE, 0);
 
-    /* set main window */
-    main_window.df = display_field;
-    main_window.widget = window;
-    main_window.timer_widget = label_timer;
-    main_window._3BV_widget = label_3BV;
-    main_window.mines_count_widget = label_mines_count;
-    main_window.mode = MODE_NORMAL;
+	container = gtk_vbox_new(FALSE, 0);
+	gtk_container_add(GTK_CONTAINER(window), container);
 
-    /* set predefined window state if it is */
-    set_predefined_state(&main_window, &miner_config);
-    /* show widgets */
-    gtk_widget_show(window);
-    gtk_widget_show(container);
-    gtk_widget_show(hbox_top);
-    gtk_widget_show(hbox_bottom);
-    gtk_widget_show(button_new);
-    gtk_widget_show(label_timer);
-    gtk_widget_show(label_3BV);
-    gtk_widget_show(label_mines_count);
-    gtk_widget_show(display_field->widget);
-    gtk_widget_show(label_field_state);
-    gtk_widget_show(menu_bar);
-    gtk_widget_show(menu_game);
-    gtk_widget_show(game_menu);
-    gtk_widget_show(game_quit);
-    gtk_widget_show(game_large);
-    gtk_widget_show(game_medium);
-    gtk_widget_show(game_small);
-    gtk_widget_show(game_scores);
-    gtk_widget_show(game_video);
+	/* box for top panel */
+	hbox_top = gtk_hbox_new(TRUE, 0);
 
-    /* create pixmaps */
-    draw = display_field->widget->window;
-    pixmap_opened = gdk_pixmap_create_from_xpm(draw, NULL, NULL, OPENED_XPM);
-    pixmap_marked = gdk_pixmap_create_from_xpm(draw, NULL, NULL, MARKED_XPM);
-    pixmap_closed = gdk_pixmap_create_from_xpm(draw, NULL, NULL, CLOSED_XPM);
-    pixmap_boom = gdk_pixmap_create_from_xpm(draw, NULL, NULL, BOOM_XPM); 
-    pixmap_mine = gdk_pixmap_create_from_xpm(draw, NULL, NULL, MINE_XPM); 
-    pixmap_pressed = gdk_pixmap_create_from_xpm(draw, NULL, NULL, PRESSED_XPM); 
+	/* box for bottom panel */
+	hbox_bottom = gtk_hbox_new(TRUE, 0);
 
-    for (i=1; i<9; i++) {
-        g_snprintf(xpm_file_name, sizeof(xpm_file_name), "pixmaps/%d.xpm", i); 
-        pixmap_numbers[i-1] = gdk_pixmap_create_from_xpm(draw,
-                NULL, NULL, xpm_file_name);
-    }
+	/* create field status indicator label */
+	label_field_state = gtk_label_new("READY");
+	gtk_box_pack_end(GTK_BOX(hbox_top), label_field_state,
+	                 FALSE, FALSE, 0);
 
-    gtk_main();
-    return 0;
+	/* create field */
+	mines_field = mf_new(NULL, miner_config.width,
+	                     miner_config.height, miner_config.bombs);
+
+	/* create display field field */
+	display_field = display_field_new(mines_field,
+	                                  G_OBJECT(label_field_state),
+	                                  field_change_status_handler, 20);
+
+	/* create button new*/
+	button_new = gtk_button_new_with_label("NEW");
+	gtk_box_pack_end(GTK_BOX(hbox_top), button_new,
+	                 FALSE, FALSE, 0);
+	g_signal_connect(G_OBJECT(button_new), "clicked",
+	                 G_CALLBACK(button_new_field_pressed), display_field);
+
+	/* create mines count */
+	label_mines_count = gtk_label_new("M: --");
+	gtk_box_pack_end(GTK_BOX(hbox_top), label_mines_count,
+	                 FALSE, FALSE, 0);
+
+	/* create timer */
+	label_timer = gtk_label_new("000:00");
+	gtk_box_pack_end(GTK_BOX(hbox_bottom), label_timer,
+	                 FALSE, FALSE, 0);
+
+	/* create 3BV */
+	label_3BV = gtk_label_new("3BV: ---");
+	gtk_box_pack_end(GTK_BOX(hbox_bottom), label_3BV,
+	                 FALSE, FALSE, 0);
+
+
+	/* construct menu*/
+	game_menu = gtk_menu_new();
+	game_small = gtk_menu_item_new_with_label("Small");
+	game_quit = gtk_menu_item_new_with_label("Quit");
+	game_large = gtk_menu_item_new_with_label("Large");
+	game_medium = gtk_menu_item_new_with_label("Medium");
+	game_scores = gtk_menu_item_new_with_label("Scores");
+	game_video = gtk_menu_item_new_with_label("Play video");
+
+	gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_small);
+	gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_medium);
+	gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_large);
+	gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_video);
+	gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_scores);
+	gtk_menu_shell_append(GTK_MENU_SHELL(game_menu), game_quit);
+
+	g_signal_connect(G_OBJECT(game_small), "activate",
+	                 G_CALLBACK(menu_handler), (gpointer)MENU_GAME_SMALL);
+	g_signal_connect(G_OBJECT(game_quit), "activate",
+	                 G_CALLBACK(menu_handler), (gpointer)MENU_GAME_QUIT);
+	g_signal_connect(G_OBJECT(game_large), "activate",
+	                 G_CALLBACK(menu_handler), (gpointer)MENU_GAME_LARGE);
+	g_signal_connect(G_OBJECT(game_medium), "activate",
+	                 G_CALLBACK(menu_handler), (gpointer)MENU_GAME_MEDIUM);
+	g_signal_connect(G_OBJECT(game_video), "activate",
+	                 G_CALLBACK(menu_handler), (gpointer)MENU_GAME_VIDEO);
+	g_signal_connect(G_OBJECT(game_scores), "activate",
+	                 G_CALLBACK(menu_handler), (gpointer)MENU_GAME_SCORES);
+
+	menu_bar = gtk_menu_bar_new();
+	menu_game = gtk_menu_item_new_with_label("Game");
+	gtk_menu_item_set_submenu(GTK_MENU_ITEM(menu_game), game_menu);
+	gtk_menu_bar_append(GTK_MENU_BAR(menu_bar), menu_game);
+
+	/* pack widgets into main container */
+	gtk_box_pack_start(GTK_BOX(container), menu_bar, TRUE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(container), hbox_top, FALSE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(container), display_field->widget, TRUE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(container), hbox_bottom, FALSE, TRUE, 0);
+
+	/* set sizes */
+	/* gtk_widget_set_size_request(window,
+	   mines_field->width*display_field->cell_size+40,
+	   mines_field->height*display_field->cell_size+150);
+	   gtk_widget_set_size_request(button_new, 60, 32); */
+
+	/* set main window */
+	main_window.df = display_field;
+	main_window.widget = window;
+	main_window.timer_widget = label_timer;
+	main_window._3BV_widget = label_3BV;
+	main_window.mines_count_widget = label_mines_count;
+	main_window.mode = MODE_NORMAL;
+
+	/* set predefined window state if it is */
+	set_predefined_state(&main_window, &miner_config);
+	/* show widgets */
+	gtk_widget_show(window);
+	gtk_widget_show(container);
+	gtk_widget_show(hbox_top);
+	gtk_widget_show(hbox_bottom);
+	gtk_widget_show(button_new);
+	gtk_widget_show(label_timer);
+	gtk_widget_show(label_3BV);
+	gtk_widget_show(label_mines_count);
+	gtk_widget_show(display_field->widget);
+	gtk_widget_show(label_field_state);
+	gtk_widget_show(menu_bar);
+	gtk_widget_show(menu_game);
+	gtk_widget_show(game_menu);
+	gtk_widget_show(game_quit);
+	gtk_widget_show(game_large);
+	gtk_widget_show(game_medium);
+	gtk_widget_show(game_small);
+	gtk_widget_show(game_scores);
+	gtk_widget_show(game_video);
+
+	/* create pixmaps */
+	draw = display_field->widget->window;
+	pixmap_opened = gdk_pixmap_create_from_xpm(draw, NULL, NULL, OPENED_XPM);
+	pixmap_marked = gdk_pixmap_create_from_xpm(draw, NULL, NULL, MARKED_XPM);
+	pixmap_closed = gdk_pixmap_create_from_xpm(draw, NULL, NULL, CLOSED_XPM);
+	pixmap_boom = gdk_pixmap_create_from_xpm(draw, NULL, NULL, BOOM_XPM);
+	pixmap_mine = gdk_pixmap_create_from_xpm(draw, NULL, NULL, MINE_XPM);
+	pixmap_pressed = gdk_pixmap_create_from_xpm(draw, NULL, NULL, PRESSED_XPM);
+
+	for (i = 1; i < 9; i++) {
+		g_snprintf(xpm_file_name, sizeof(xpm_file_name), "pixmaps/%d.xpm", i);
+		pixmap_numbers[i - 1] = gdk_pixmap_create_from_xpm(draw,
+		                        NULL, NULL, xpm_file_name);
+	}
+
+	gtk_main();
+	return 0;
 }

--- a/mines_field.c
+++ b/mines_field.c
@@ -28,281 +28,277 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-gint random_number (gint min, gint max)
+gint random_number(gint min, gint max)
 {
-    static gint dev_random_fd = -1;
+	static gint dev_random_fd = -1;
 
-    gchar* next_random_byte;
-    gint bytes_to_read;
-    guint random_value;
+	gchar* next_random_byte;
+	gint bytes_to_read;
+	guint random_value;
 
-    if (max < min) return -1;
+	if (max < min) return -1;
 
-    if (dev_random_fd == -1) {
-        dev_random_fd = open ("/dev/urandom", O_RDONLY);
-        if (dev_random_fd == -1) return -1;
-    }
-    next_random_byte = (gchar*) &random_value;
-    bytes_to_read = sizeof (random_value);
+	if (dev_random_fd == -1) {
+		dev_random_fd = open("/dev/urandom", O_RDONLY);
+		if (dev_random_fd == -1) return -1;
+	}
+	next_random_byte = (gchar*) &random_value;
+	bytes_to_read = sizeof(random_value);
 
-    do {
-        gint bytes_read;
-        bytes_read = read (dev_random_fd, next_random_byte, bytes_to_read);
-        bytes_to_read -= bytes_read;
-        next_random_byte += bytes_read;
-    } while (bytes_to_read > 0);
+	do {
+		gint bytes_read;
+		bytes_read = read(dev_random_fd, next_random_byte, bytes_to_read);
+		bytes_to_read -= bytes_read;
+		next_random_byte += bytes_read;
+	} while (bytes_to_read > 0);
 
-    return min + (random_value % (max - min + 1));
+	return min + (random_value % (max - min + 1));
 }
 
 MinesField* mf_new(MinesField* mf, gint width, gint height, gint bombs)
 {
-    gint i, j;
-    gint bombed_cell;
-    MinesField *mines_field;
+	gint i, j;
+	gint bombed_cell;
+	MinesField *mines_field;
 
-    if (mf==NULL) { 
+	if (mf == NULL)
 		mines_field = (MinesField*)g_malloc(sizeof(MinesField));
-    } else {
+	else {
 		mines_field = mf;
-    	for (i=0; i<mf->width; i++)
-	    	g_free(mf->cell[i]);
+		for (i = 0; i < mf->width; i++)
+			g_free(mf->cell[i]);
 		g_free(mf->cell);
-    }
-    
-    mines_field->cell = (gint**)g_malloc(sizeof(int*)*width);
-    
-    for (i=0; i<width; i++) 
-		mines_field->cell[i] = (gint*)g_malloc(sizeof(int)*height);
+	}
 
-    mines_field->width = width;
-    mines_field->height = height;
-    mines_field->is_fail = FALSE;
-    mines_field->opened_count = 0;
-    mines_field->fully_opened = FALSE;
-    mines_field->bombs = 0;
-    mines_field->marked_count = 0;
+	mines_field->cell = (gint**)g_malloc(sizeof(int*)*width);
 
-    for (i=0; i<width; i++) { 
-		for (j=0; j<height; j++)  {
-		    mines_field->cell[i][j] = 0;
-		    mines_field->cell[i][j] |= NEED_UPDATE;
+	for (i = 0; i < width; i++)
+		mines_field->cell[i] = (gint*)g_malloc(sizeof(int) * height);
+
+	mines_field->width = width;
+	mines_field->height = height;
+	mines_field->is_fail = FALSE;
+	mines_field->opened_count = 0;
+	mines_field->fully_opened = FALSE;
+	mines_field->bombs = 0;
+	mines_field->marked_count = 0;
+
+	for (i = 0; i < width; i++) {
+		for (j = 0; j < height; j++)  {
+			mines_field->cell[i][j] = 0;
+			mines_field->cell[i][j] |= NEED_UPDATE;
 		}
-    }
+	}
 
-    for (;mines_field->bombs < bombs;) {
-		bombed_cell = random_number(0, width*height-1);
-        if (bombed_cell < 0) {
-            fprintf(stderr, "random failed\n");
-            bombed_cell = 0;
-        }
-		i = (gint)(bombed_cell/mines_field->height);
+	for (; mines_field->bombs < bombs;) {
+		bombed_cell = random_number(0, width * height - 1);
+		if (bombed_cell < 0) {
+			fprintf(stderr, "random failed\n");
+			bombed_cell = 0;
+		}
+		i = (gint)(bombed_cell / mines_field->height);
 		j = (gint)(bombed_cell % mines_field->height);
-		
+
 		if (!(mines_field->cell[i][j] & BOMBED)) {
-		    mines_field->cell[i][j] |= BOMBED;
-		    mines_field->bombs++;
+			mines_field->cell[i][j] |= BOMBED;
+			mines_field->bombs++;
 		}
-    }
-    return (mines_field);
+	}
+	return (mines_field);
 }
 
 void mf_set_opened(MinesField *mf, gint x, gint y)
 {
-    if (x>=0 && x<mf->height && y>=0 && y<mf->width && !(mf->cell[x][y]&MARKED)) {
+	if (x >= 0 && x < mf->height && y >= 0 && y < mf->width && !(mf->cell[x][y]&MARKED))
 		mf->cell[x][y] |= OPENED;
-	}
 }
 
 void mf_set_mraked(MinesField *mf, gint x, gint y)
 {
-    if (x>=0 && x<mf->height && y>=0 && y<mf->width && !(mf->cell[x][y]&OPENED)) {
+	if (x >= 0 && x < mf->height && y >= 0 && y < mf->width && !(mf->cell[x][y]&OPENED)) {
 		mf->cell[x][y] |= MARKED;
 		mf->marked_count++;
-    }
+	}
 }
 
 gint mf_get_number(MinesField *mf, gint x, gint y)
 {
-    int bombs_count = 0;
-    int i, j;
-    for (i=max(0, x-1); i<min(mf->width, x+2); i++) {
-		for (j=max(0, y-1); j<min(mf->height, y+2); j++) {
-		    if (mf->cell[i][j]&BOMBED) {
+	int bombs_count = 0;
+	int i, j;
+	for (i = max(0, x - 1); i < min(mf->width, x + 2); i++) {
+		for (j = max(0, y - 1); j < min(mf->height, y + 2); j++) {
+			if (mf->cell[i][j]&BOMBED)
 				bombs_count++;
-		    }
 		}
-    }
-			
-    return bombs_count;
+	}
+
+	return bombs_count;
 }
 
 gint mf_get_marked(MinesField *mf, gint x, gint y)
 {
-    int marked_count = 0;
-    int i, j;
-    for (i=max(0, x-1); i<min(mf->width, x+2); i++)
-		for (j=max(0, y-1); j<min(mf->height, y+2); j++)
-	    	if (mf->cell[i][j]&MARKED)
+	int marked_count = 0;
+	int i, j;
+	for (i = max(0, x - 1); i < min(mf->width, x + 2); i++)
+		for (j = max(0, y - 1); j < min(mf->height, y + 2); j++)
+			if (mf->cell[i][j]&MARKED)
 				marked_count++;
-				
-    return marked_count;
+
+	return marked_count;
 }
 
 gboolean mf_set_state(MinesField *mf,
-       	gint x, gint y,
-       	SellStatus status)
+                      gint x, gint y,
+                      SellStatus status)
 {
-    int i, j;
-    SellStatus prev_status;
+	int i, j;
+	SellStatus prev_status;
 
-    if ((x<0 || x>=mf->width)
-	    || (y<0 || y>=mf->height))
-	    return FALSE;
+	if ((x < 0 || x >= mf->width)
+	        || (y < 0 || y >= mf->height))
+		return FALSE;
 
-    prev_status = mf->cell[x][y];
+	prev_status = mf->cell[x][y];
 
-    if ( (status&OPENED) && !(mf->cell[x][y]&MARKED)
-	    && !(mf->cell[x][y]&OPENED)) {
-	    	
+	if ((status & OPENED) && !(mf->cell[x][y]&MARKED)
+	        && !(mf->cell[x][y]&OPENED)) {
+
 		mf->cell[x][y] |= OPENED;
 		mf->opened_count++;
-    	if (mf_get_number(mf, x, y) == 0 && mf_get_marked(mf, x, y) == 0) 
-    	    for (i=max(0, x-1); i<min(mf->width, x+2); i++)
-    			for (j=max(0, y-1); j<min(mf->height, y+2); j++)
-    		    	if ( !(mf->cell[i][j]&OPENED) )
-    					mf_set_state(mf, i, j, OPENED);
-    }
+		if (mf_get_number(mf, x, y) == 0 && mf_get_marked(mf, x, y) == 0)
+			for (i = max(0, x - 1); i < min(mf->width, x + 2); i++)
+				for (j = max(0, y - 1); j < min(mf->height, y + 2); j++)
+					if (!(mf->cell[i][j]&OPENED))
+						mf_set_state(mf, i, j, OPENED);
+	}
 
-    if ( (status&MARKED) && (mf->cell[x][y]&MARKED) ) { 
+	if ((status & MARKED) && (mf->cell[x][y]&MARKED)) {
 		mf->cell[x][y] ^= MARKED;
 		mf->marked_count--;
-    } else if ( (status&MARKED) && !(mf->cell[x][y]&OPENED) ) {
-	    mf->cell[x][y] |= MARKED;
-	    mf->marked_count++;
-    }
+	} else if ((status & MARKED) && !(mf->cell[x][y]&OPENED)) {
+		mf->cell[x][y] |= MARKED;
+		mf->marked_count++;
+	}
 
-    if ( (mf->cell[x][y]&OPENED) && (mf->cell[x][y]&BOMBED) ) {
-		if (mf->opened_count<=1) { 
-		    mf_new_field(mf);
-		    mf_set_state(mf, x, y, OPENED);
+	if ((mf->cell[x][y]&OPENED) && (mf->cell[x][y]&BOMBED)) {
+		if (mf->opened_count <= 1) {
+			mf_new_field(mf);
+			mf_set_state(mf, x, y, OPENED);
 		} else {
-	    	mf->is_fail = TRUE;
-            return TRUE;
+			mf->is_fail = TRUE;
+			return TRUE;
 		}
-    }
+	}
 
-    if (prev_status != mf->cell[x][y])
+	if (prev_status != mf->cell[x][y])
 		mf->cell[x][y] |= NEED_UPDATE;
 
-    if ( (mf->opened_count >= mf->height*mf->width - mf->bombs) )
+	if ((mf->opened_count >= mf->height * mf->width - mf->bombs))
 		mf->fully_opened = TRUE;
 
-    return TRUE;
+	return TRUE;
 }
 
-gboolean mf_set_state_around(MinesField *mf, 
-	gint x, gint y,
-       	gint state)
+gboolean mf_set_state_around(MinesField *mf,
+                             gint x, gint y,
+                             gint state)
 {
-    int i, j;
+	int i, j;
 
-    if ((x<0 || x>=mf->width)
-	    || (y<0 || y>=mf->height))
-	    return FALSE;
-    
-    if ( (mf_get_marked(mf, x, y) == mf_get_number(mf, x, y)
-	    && state==OPENED && mf_get_marked(mf, x, y)>0) ) {
-		for (i=max(0, x-1); i<min(mf->width, x+2); i++)
-		    for (j=max(0, y-1); j<min(mf->height, y+2); j++)
-				if ( !(mf->cell[i][j]&OPENED) && !(mf->cell[i][j]&MARKED) )
-				    mf_set_state(mf, i, j, state);
-    }
+	if ((x < 0 || x >= mf->width)
+	        || (y < 0 || y >= mf->height))
+		return FALSE;
 
-    return TRUE;
+	if ((mf_get_marked(mf, x, y) == mf_get_number(mf, x, y)
+	        && state == OPENED && mf_get_marked(mf, x, y) > 0)) {
+		for (i = max(0, x - 1); i < min(mf->width, x + 2); i++)
+			for (j = max(0, y - 1); j < min(mf->height, y + 2); j++)
+				if (!(mf->cell[i][j]&OPENED) && !(mf->cell[i][j]&MARKED))
+					mf_set_state(mf, i, j, state);
+	}
+
+	return TRUE;
 }
 
 void mf_new_field(MinesField *mf)
 {
-    gint i, j;
-    gint bombs;
-    gint bombed_cell;
+	gint i, j;
+	gint bombs;
+	gint bombed_cell;
 
-    mf->is_fail = FALSE;
-    mf->opened_count = 0;
-    mf->fully_opened = FALSE;
+	mf->is_fail = FALSE;
+	mf->opened_count = 0;
+	mf->fully_opened = FALSE;
 
-    bombs = mf->bombs;
-    mf->bombs = 0;
+	bombs = mf->bombs;
+	mf->bombs = 0;
 
-    for (i=0; i<mf->width; i++) { 
-		for (j=0; j<mf->height; j++)  {
-		    if (!(mf->cell[i][j]&NEED_UPDATE)) {
+	for (i = 0; i < mf->width; i++) {
+		for (j = 0; j < mf->height; j++)  {
+			if (!(mf->cell[i][j]&NEED_UPDATE))
 				mf->cell[i][j] = 0;
-		    } else {
+			else {
 				mf->cell[i][j] = 0;
 				mf->cell[i][j] |= NEED_UPDATE;
-		    }
+			}
 		}
-    }
+	}
 
-    for (;mf->bombs < bombs;) {
-    	
-		bombed_cell = random_number(0, mf->width*mf->height-1);
-		i = (gint)(bombed_cell/mf->height);
+	for (; mf->bombs < bombs;) {
+
+		bombed_cell = random_number(0, mf->width * mf->height - 1);
+		i = (gint)(bombed_cell / mf->height);
 		j = (gint)(bombed_cell % mf->height);
-		
+
 		if (!(mf->cell[i][j] & BOMBED)) {
-		    mf->cell[i][j] |= BOMBED;
-		    mf->bombs++;
+			mf->cell[i][j] |= BOMBED;
+			mf->bombs++;
 		}
-    }
+	}
 }
 
 gint mf_get_3BV_index(MinesField *mf, gint x, gint y)
 {
-    gint i, j;
-    gint _3BV_index = 0;
+	gint i, j;
+	gint _3BV_index = 0;
 
-    if ((x<0 || x>=mf->width)
-	    || (y<0 || y>=mf->height))
-	    return -1;
+	if ((x < 0 || x >= mf->width)
+	        || (y < 0 || y >= mf->height))
+		return -1;
 
-    if (!(mf->cell[x][y]&MARKED)) {
+	if (!(mf->cell[x][y]&MARKED)) {
 		mf->cell[x][y] |= MARKED;
 		_3BV_index = 1;
-    	if (mf_get_number(mf, x, y) == 0)
-    	    for (i=max(0, x-1); i<min(mf->width, x+2); i++)
-    		for (j=max(0, y-1); j<min(mf->height, y+2); j++)
-    		    if ( !(mf->cell[i][j]&MARKED) )
-    				mf_get_3BV_index(mf, i, j);
-    }
+		if (mf_get_number(mf, x, y) == 0)
+			for (i = max(0, x - 1); i < min(mf->width, x + 2); i++)
+				for (j = max(0, y - 1); j < min(mf->height, y + 2); j++)
+					if (!(mf->cell[i][j]&MARKED))
+						mf_get_3BV_index(mf, i, j);
+	}
 
-    return _3BV_index;
+	return _3BV_index;
 }
 
 gint mf_get_3BV(MinesField *mf)
 {
-    int i, j;
-    int _3BV_value = 0;
-    for (i=0; i<mf->width; i++)
-		for (j=0; j<mf->height; j++)
-	    	if (mf_get_number(mf, i, j) == 0) {
+	int i, j;
+	int _3BV_value = 0;
+	for (i = 0; i < mf->width; i++)
+		for (j = 0; j < mf->height; j++)
+			if (mf_get_number(mf, i, j) == 0)
 				_3BV_value += mf_get_3BV_index(mf, i, j);
-	    	}	
 
-    for (i=0; i<mf->width; i++)
-		for (j=0; j<mf->height; j++)
-	    	if (mf_get_number(mf, i, j) != 0
-		    	&& !(mf->cell[i][j]&BOMBED)) {
+	for (i = 0; i < mf->width; i++)
+		for (j = 0; j < mf->height; j++)
+			if (mf_get_number(mf, i, j) != 0
+			        && !(mf->cell[i][j]&BOMBED))
 				_3BV_value += mf_get_3BV_index(mf, i, j);
-	    	}	
 
-    for (i=0; i<mf->width; i++)
-		for (j=0; j<mf->height; j++)
-	    	mf->cell[i][j] &= ~MARKED;
+	for (i = 0; i < mf->width; i++)
+		for (j = 0; j < mf->height; j++)
+			mf->cell[i][j] &= ~MARKED;
 
-    return _3BV_value;
+	return _3BV_value;
 }
 
 


### PR DESCRIPTION
This attempts to make the code style consistant without making drastic changes to the style. It was done with the astyle utility (and some by hand) with the following options file:

```
lineend=linux           # (already using)
indent=tab              # Tabs for indentation, spaces for alignment
pad-oper                # 2 + 2 * 4 instead of 2+2*4
pad-header              # if () instead of if()
unpad-paren             # if (1) instead of if ( 1 )
align-reference=name    # char *foo instead of char* foo
remove-brackets         # Single-statement conditionals don't use brackets
```

Let me know if there is is anything that should be done differently (such as indentation style).